### PR TITLE
fix the portmap setup issues

### DIFF
--- a/hypervisor/driver.go
+++ b/hypervisor/driver.go
@@ -69,6 +69,7 @@ type LazyDriverContext interface {
 	DriverContext
 
 	LazyLaunch(ctx *VmContext)
+	InitVM(ctx *VmContext) error
 	LazyAddDisk(ctx *VmContext, name, sourceType, filename, format string, id int)
 	LazyAddNic(ctx *VmContext, host *HostNicInfo, guest *GuestNicInfo)
 }

--- a/hypervisor/lazy.go
+++ b/hypervisor/lazy.go
@@ -29,6 +29,17 @@ func LazyVmLoop(vmId string, hub chan VmEvent, client chan *types.VmResponse, bo
 		return
 	}
 
+	err = context.DCtx.(LazyDriverContext).InitVM(context)
+	if err != nil {
+		estr := fmt.Sprintf("failed to create VM(%s): %s", vmId, err.Error())
+		glog.Error(estr)
+		client <- &types.VmResponse{
+			VmId:  vmId,
+			Code:  types.E_BAD_REQUEST,
+			Cause: estr,
+		}
+		return
+	}
 	context.Become(statePreparing, "PREPARING")
 
 	context.loop()

--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -445,7 +445,7 @@ func (vc *VBoxContext) LazyAddNic(ctx *hypervisor.VmContext, host *hypervisor.Ho
 	vc.callbacks = append(vc.callbacks, callback)
 }
 
-func (vc *VBoxContext) initVM(ctx *hypervisor.VmContext) error {
+func (vc *VBoxContext) InitVM(ctx *hypervisor.VmContext) error {
 	vmRootPath := path.Join(hypervisor.BaseDir, "vm")
 	os.MkdirAll(vmRootPath, 0755)
 	m, err := virtualbox.GetMachine(ctx.Id)
@@ -501,14 +501,6 @@ func (vc *VBoxContext) LazyLaunch(ctx *hypervisor.VmContext) {
 			glog.Errorf("fail to start %s, should I delete it?", ctx.Id)
 		}
 	}()
-
-	err = vc.initVM(ctx)
-	if err != nil {
-		estr := fmt.Sprintf("failed to create VM(%s): %s", ctx.Id, err.Error())
-		glog.Error(estr)
-		ctx.Hub <- &hypervisor.VmStartFailEvent{Message: estr}
-		return
-	}
 
 	m := vc.Machine
 

--- a/lib/govbox/machine.go
+++ b/lib/govbox/machine.go
@@ -370,6 +370,10 @@ func (m *Machine) NicConf(n int, nic NIC) []string {
 	if nic.Network == "bridged" {
 		args = append(args, fmt.Sprintf("--bridgeadapter%d", n), nic.BridgedAdapter)
 	}
+	if nic.Network == "nat" {
+		args = append(args, fmt.Sprintf("--natdnshostresolver%d", n), "on")
+	}
+
 	if nic.NatNet != "" {
 		args = append(args, fmt.Sprintf("--natnet%d", n), nic.NatNet)
 	}


### PR DESCRIPTION
### Root Cause

The portmap setup is started before creating the vm, so it will not find that vm to `modifyvm`.  The details of failure is:

```
[HYPER INFO  0818 15:22:27 35662 vbm.go] [:42] executing: VBoxManage modifyvm vm-chnXGjrLbk --natpf1 vm-chnXGjrLbk,tcp,,80,192.168.123.7,8080
VBoxManage: error: Could not find a registered machine named 'vm-chnXGjrLbk'
VBoxManage: error: Details: code VBOX_E_OBJECT_NOT_FOUND (0x80bb0001), component VirtualBoxWrap, interface IVirtualBox, callee nsISupports
VBoxManage: error: Context: "FindMachine(Bstr(a->argv[0]).raw(), machine.asOutParam())" at line 485 of file VBoxManageModifyVM.cpp
[HYPER ERROR 0818 15:22:27 35662 network.go] [:123] Setup Port Map failed exit status 1
[HYPER INFO  0818 15:22:27 35662 vbm.go] [:70] executing: VBoxManage showvminfo vm-chnXGjrLbk --machinereadable
[HYPER INFO  0818 15:22:27 35662 vbm.go] [:42] executing: VBoxManage createvm --name vm-chnXGjrLbk --register --basefolder /var/run/hyper/vm
Virtual machine 'vm-chnXGjrLbk' is created and registered.
UUID: 23c3e52e-ff38-46bd-bc5e-41dba362f502
Settings file: '/var/run/hyper/vm/vm-chnXGjrLbk/vm-chnXGjrLbk.vbox'
[HYPER INFO  0818 15:22:27 35662 vbm.go] [:70] executing: VBoxManage showvminfo vm-chnXGjrLbk --machinereadable
[HYPER INFO  0818 15:22:27 35662 vbm.go] [:42] executing: VBoxManage modifyvm vm-chnXGjrLbk --firmware bios --bioslogofadein off --bioslogofadeout off --bioslogodisplaytime 0 --biosbootmenu disabled --ostype Linux_64 --cpus 1 --memory 128 --vram 8 --acpi on --ioapic on --rtcuseutc off --cpuhotplug off --pae off --longmode on --hpet off --hwvirtex on --triplefaultreset off --nestedpaging off --largepages off --vtxvpid on --vtxux on --accelerate3d off --boot1 dvd --uart1 0x03F8 4 --uartmode1 server /var/run/hyper/vm-chnXGjrLbk/hyper.sock --uart2 0x02F8 3 --uartmode2 server /var/run/hyper/vm-chnXGjrLbk/tty.sock --nic1 nat --nictype1 82545EM --cableconnected1 on --natdnshostresolver1 on --natnet1 192.168.123.0/24
[HYPER INFO  0818 15:22:27 35662 vbm.go] [:70] executing: VBoxManage showvminfo vm-chnXGjrLbk --machinereadable
[HYPER INFO  0818 15:22:27 35662 vbm.go] [:42] executing: VBoxManage storagectl vm-chnXGjrLbk --name vm-chnXGjrLbk --add sata --portcount 2 --hostiocache on --bootable on
[HYPER INFO  0818 15:22:27 35662 vbm.go] [:42] executing: VBoxManage storageattach vm-chnXGjrLbk --storagectl vm-chnXGjrLbk --port 0 --device 0 --type dvddrive --medium /var/lib/hyper/hyper-vbox-boot.iso
[HYPER INFO  0818 15:22:28 35662 vbm.go] [:42] executing: VBoxManage storageattach vm-chnXGjrLbk --storagectl vm-chnXGjrLbk --port 1 --device 0 --type hdd --medium /var/lib/hyper/vbox/images/cda295d20ae69a1b72bd216bf251e95222a77903a7d3cdf0660ccb01e660d2e4.vdi --nonrotational on
[HYPER INFO  0818 15:22:28 35662 vbm.go] [:42] executing: VBoxManage sharedfolder add vm-chnXGjrLbk --name share_dir --hostpath /var/run/hyper/vm-chnXGjrLbk/share_dir
[HYPER INFO  0818 15:22:28 35662 vbm.go] [:42] executing: VBoxManage startvm vm-chnXGjrLbk --type gui
[HYPER INFO  0818 15:22:29 35662 tty.go] [:126] tty socket connected
[HYPER INFO  0818 15:22:29 35662 tty.go] [:69] tty: trying to read 12 bytes
[HYPER INFO  0818 15:22:29 35662 init_comm.go] [:110] Wating for init messages...
[HYPER INFO  0818 15:22:29 35662 init_comm.go] [:73] trying to read 8 bytes
Waiting for VM "vm-chnXGjrLbk" to power on...
VM "vm-chnXGjrLbk" has been successfully started.
[HYPER INFO  0818 15:22:29 35662 context.go] [:243] VM vm-chnXGjrLbk: state change from PREPARING to 'STARTING'
[HYPER INFO  0818 15:22:29 35662 hypervisor.go] [:29] main event loop got message 15(EVENT_INTERFACE_INSERTED)
[HYPER INFO  0818 15:22:29 35662 hypervisor.go] [:29] main event loop got message 10(EVENT_BLOCK_INSERTED)
[HYPER INFO  0818 15:22:29 35662 vm_states.go] [:331] device ready, could run pod.
```

### Test

With the fix, the portmap is setup successfully, you can find the ![result](http://img6.douban.com/view/photo/photo/public/p2263245545.jpg)