### PR TITLE
validate volume driver

### DIFF
--- a/hypervisor/pod/pod.go
+++ b/hypervisor/pod/pod.go
@@ -161,6 +161,13 @@ func RandStr(strSize int, randType string) string {
 // 3. container should not use volume/file not in volume/file list
 // 4. environment var should be uniq in one container
 func (pod *UserPod) Validate() error {
+	var volume_drivers = map[string]bool {
+		"raw":		true,
+		"qcow2":	true,
+		"vdi":		true,
+		"vfs":		true,
+	}
+
 	uniq, vset := keySet(pod.Volumes)
 	if !uniq {
 		if len(vset) > 0 {
@@ -203,6 +210,16 @@ func (pod *UserPod) Validate() error {
 			if _, ok := vset[v.Volume]; !ok {
 				return fmt.Errorf("in container %d, volume %s does not exist in volume list.", idx, v.Volume)
 			}
+		}
+	}
+
+	for idx, v := range pod.Volumes {
+		if v.Driver == "" {
+			continue
+		}
+
+		if _, ok := volume_drivers[v.Driver]; !ok {
+			return fmt.Errorf("in volume %d, volume does not support driver %s.", idx, v.Driver)
 		}
 	}
 


### PR DESCRIPTION
fix panic bug

[HYPER INFO  0819 18:56:35 17405 hypervisor.go] [:29] main event loop got message 21(COMMAND_RUN_POD)
[HYPER INFO  0819 18:56:35 17405 vm_states.go] [:315] got spec, prepare devices
[HYPER INFO  0819 18:56:35 17405 context.go] [:269] #0 Container Info:
[HYPER INFO  0819 18:56:35 17405 context.go] [:272]
{
...|    "Id": "fdaf47a5466485f7c0b189be751be9f15a7c461f08fa7fa92b51847c1e8d880d",
...|    "Rootfs": "",
...|    "Image": "/fdaf47a5466485f7c0b189be751be9f15a7c461f08fa7fa92b51847c1e8d880d/rootfs",
...|    "Fstype": "dir",
...|    "Workdir": "",
...|    "Entrypoint": null,
...|    "Cmd": [
...|        "/bin/bash"
...|    ],
...|    "Envs": {}
...|}
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x8 pc=0x4cb743]

goroutine 74 [running]:
github.com/hyperhq/runv/hypervisor.(*VmContext).initContainerInfo(0xc208270b40, 0x0, 0xc208219ea0, 0xc2081d3450)
	/home/gaofeng/go/src/github.com/hyperhq/runv/hypervisor/devicemap.go:100 +0x193
github.com/hyperhq/runv/hypervisor.(*VmContext).InitDeviceContext(0xc208270b40, 0xc2082b0b40, 0xc208253420, 0xc208039ec0, 0x1, 0x1, 0xc2082838a0, 0x2, 0x2)
	/home/gaofeng/go/src/github.com/hyperhq/runv/hypervisor/context.go:280 +0x679
github.com/hyperhq/runv/hypervisor.(*VmContext).prepareDevice(0xc208270b40, 0xc2082f4140, 0xc2082f4140)
	/home/gaofeng/go/src/github.com/hyperhq/runv/hypervisor/vm_states.go:55 +0x19f
github.com/hyperhq/runv/hypervisor.stateInit(0xc208270b40, 0x7f8c79a3fd48, 0xc2082f4140)
	/home/gaofeng/go/src/github.com/hyperhq/runv/hypervisor/vm_states.go:316 +0x613
[HYPER INFO  0819 18:56:35 17405 qemu_process.go] [:59] I am the parent, exit, ps: child 17435
[HYPER INFO  0819 18:56:35 17405 qemu_process.go] [:107] qemu daemon pid 17435.
github.com/hyperhq/runv/hypervisor.(*VmContext).loop(0xc208270b40)
	/home/gaofeng/go/src/github.com/hyperhq/runv/hypervisor/hypervisor.go:30 +0x455
github.com/hyperhq/runv/hypervisor.VmLoop(0xc208283380, 0xd, 0xc20828bb00, 0xc20828bb60, 0xc20828baa0, 0x0)
	/home/gaofeng/go/src/github.com/hyperhq/runv/hypervisor/hypervisor.go:49 +0x20a
created by github.com/hyperhq/runv/hypervisor.(*Vm).Launch
	/home/gaofeng/go/src/github.com/hyperhq/runv/hypervisor/vm.go:60 +0x32e

Signed-off-by: Gao feng <omarapazanadi@gmail.com>