### PR TITLE
update interface pod

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -250,6 +250,12 @@ func (ctx *VmContext) InitDeviceContext(spec *pod.UserPod, wg *sync.WaitGroup,
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
+	/* Update interface count accourding to user pod */
+	ret := len(spec.Interfaces)
+	if ret != 0 {
+		ctx.InterfaceCount = ret
+	}
+
 	for i := 0; i < ctx.InterfaceCount; i++ {
 		ctx.progress.adding.networks[i] = true
 	}

--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -296,6 +296,7 @@ func (ctx *VmContext) InitDeviceContext(spec *pod.UserPod, wg *sync.WaitGroup,
 	ctx.vmSpec = &VmPod{
 		Hostname:   spec.Name,
 		Containers: containers,
+		Dns:        spec.Dns,
 		Interfaces: nil,
 		Routes:     nil,
 		ShareDir:   ShareDirTag,

--- a/hypervisor/devicemap.go
+++ b/hypervisor/devicemap.go
@@ -617,7 +617,9 @@ func interfaceGot(index int, pciAddr int, name string, inf *network.Settings) (*
 	var mask net.IP = tmp
 
 	rt := []*RouteRule{}
-	if index == 0 {
+	/* Route rule is generated automaticly on first interface,
+	 * or generated on the gateway configured interface. */
+	if (index == 0 && inf.Automatic) || (!inf.Automatic && inf.Gateway != "") {
 		rt = append(rt, &RouteRule{
 			Destination: "0.0.0.0/0",
 			Gateway:     inf.Gateway, ViaThis: true,

--- a/hypervisor/devicemap.go
+++ b/hypervisor/devicemap.go
@@ -250,18 +250,14 @@ func (ctx *VmContext) setVolumeInfo(info *VolumeInfo) {
 }
 
 func (ctx *VmContext) allocateNetworks() {
-	var maps []pod.UserContainerPort
-
-	for _, c := range ctx.userSpec.Containers {
-		for _, m := range c.Ports {
-			maps = append(maps, m)
-		}
-	}
-
 	for i := range ctx.progress.adding.networks {
 		name := fmt.Sprintf("eth%d", i)
 		addr := ctx.nextPciAddr()
-		go ctx.CreateInterface(i, addr, name, maps)
+		if len(ctx.userSpec.Interfaces) > 0 {
+			go ctx.ConfigureInterface(i, addr, name, ctx.userSpec.Interfaces[i])
+		} else {
+			go ctx.CreateInterface(i, addr, name)
+		}
 	}
 }
 
@@ -518,15 +514,23 @@ func (ctx *VmContext) removeInterface() {
 	}
 }
 
-func (ctx *VmContext) allocateInterface(index int, pciAddr int, name string,
-	maps []pod.UserContainerPort) (*InterfaceCreated, error) {
-	var inf *network.Settings
+func (ctx *VmContext) allocateInterface(index int, pciAddr int, name string) (*InterfaceCreated, error) {
 	var err error
+	var inf *network.Settings
+	var maps []pod.UserContainerPort
+
+	if index == 0 {
+		for _, c := range ctx.userSpec.Containers {
+			for _, m := range c.Ports {
+				maps = append(maps, m)
+			}
+		}
+	}
 
 	if HDriver.BuildinNetwork() {
 		inf, err = ctx.DCtx.AllocateNetwork(ctx.Id, "", maps)
 	} else {
-		inf, err = network.Allocate(ctx.Id, "", index, false, maps)
+		inf, err = network.Allocate(ctx.Id, "", false, maps)
 	}
 
 	if err != nil {
@@ -538,9 +542,44 @@ func (ctx *VmContext) allocateInterface(index int, pciAddr int, name string,
 	return interfaceGot(index, pciAddr, name, inf)
 }
 
-func (ctx *VmContext) CreateInterface(index int, pciAddr int, name string,
-	maps []pod.UserContainerPort) {
-	session, err := ctx.allocateInterface(index, pciAddr, name, maps)
+func (ctx *VmContext) ConfigureInterface(index int, pciAddr int, name string, config pod.UserInterface) {
+	var err error
+	var inf *network.Settings
+	var maps []pod.UserContainerPort
+
+	if index == 0 {
+		for _, c := range ctx.userSpec.Containers {
+			for _, m := range c.Ports {
+				maps = append(maps, m)
+			}
+		}
+	}
+
+	if HDriver.BuildinNetwork() {
+		/* VBox doesn't support join to bridge */
+		inf, err = ctx.DCtx.ConfigureNetwork(ctx.Id, "", maps, config)
+	} else {
+		inf, err = network.Configure(ctx.Id, "", false, maps, config)
+	}
+
+	if err != nil {
+		glog.Error("interface creating failed: ", err.Error())
+		session := &InterfaceCreated{Index: index, PCIAddr: pciAddr, DeviceName: name}
+		ctx.Hub <- &DeviceFailed{Session: session}
+		return
+	}
+
+	session, err := interfaceGot(index, pciAddr, name, inf)
+	if err != nil {
+		ctx.Hub <- &DeviceFailed{Session: session}
+		return
+	}
+
+	ctx.Hub <- session
+}
+
+func (ctx *VmContext) CreateInterface(index int, pciAddr int, name string) {
+	session, err := ctx.allocateInterface(index, pciAddr, name)
 
 	if err != nil {
 		ctx.Hub <- &DeviceFailed{Session: session}
@@ -558,7 +597,7 @@ func (ctx *VmContext) ReleaseInterface(index int, ipAddr string, file *os.File,
 	if HDriver.BuildinNetwork() {
 		err = ctx.DCtx.ReleaseNetwork(ctx.Id, ipAddr, maps, file)
 	} else {
-		err = network.Release(ctx.Id, ipAddr, index, maps, file)
+		err = network.Release(ctx.Id, ipAddr, maps, file)
 	}
 
 	if err != nil {

--- a/hypervisor/driver.go
+++ b/hypervisor/driver.go
@@ -60,6 +60,7 @@ type DriverContext interface {
 	Shutdown(ctx *VmContext)
 	Kill(ctx *VmContext)
 
+	ConfigureNetwork(vmId, requestedIP string, maps []pod.UserContainerPort, config pod.UserInterface) (*network.Settings, error)
 	AllocateNetwork(vmId, requestedIP string, maps []pod.UserContainerPort) (*network.Settings, error)
 	ReleaseNetwork(vmId, releasedIP string, maps []pod.UserContainerPort, file *os.File) error
 
@@ -120,6 +121,11 @@ func (ec *EmptyContext) Shutdown(ctx *VmContext) {}
 func (ec *EmptyContext) Kill(ctx *VmContext) {}
 
 func (ec *EmptyContext) BuildinNetwork() bool { return false }
+
+func (ec *EmptyContext) ConfigureNetwork(vmId, requestedIP string,
+	maps []pod.UserContainerPort, config pod.UserInterface) (*network.Settings, error) {
+	return nil, nil
+}
 
 func (ec *EmptyContext) AllocateNetwork(vmId, requestedIP string,
 	maps []pod.UserContainerPort) (*network.Settings, error) {

--- a/hypervisor/lazy.go
+++ b/hypervisor/lazy.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hyperhq/runv/hypervisor/pod"
 	"github.com/hyperhq/runv/hypervisor/types"
 	"github.com/hyperhq/runv/lib/glog"
 )
@@ -114,18 +113,10 @@ func networkConfigure(info *InterfaceCreated) (*HostNicInfo, *GuestNicInfo) {
 }
 
 func (ctx *VmContext) lazyAllocateNetworks() error {
-	var maps []pod.UserContainerPort
-
-	for _, c := range ctx.userSpec.Containers {
-		for _, m := range c.Ports {
-			maps = append(maps, m)
-		}
-	}
-
 	for i := range ctx.progress.adding.networks {
 		name := fmt.Sprintf("eth%d", i)
 		addr := ctx.nextPciAddr()
-		nic, err := ctx.allocateInterface(i, addr, name, maps)
+		nic, err := ctx.allocateInterface(i, addr, name)
 		if err != nil {
 			return err
 		}

--- a/hypervisor/network/network.go
+++ b/hypervisor/network/network.go
@@ -16,6 +16,7 @@ type Settings struct {
 	Bridge      string
 	Device      string
 	File        *os.File
+	Automatic   bool
 }
 
 const (

--- a/hypervisor/network/network_darwin.go
+++ b/hypervisor/network/network_darwin.go
@@ -11,11 +11,11 @@ func InitNetwork(bIface, bIP string, disableIptables bool) error {
 	return fmt.Errorf("Generial Network driver is unsupported on this os")
 }
 
-func Allocate(vmId, requestedIP string, index int, addrOnly bool, maps []pod.UserContainerPort) (*Settings, error) {
+func Allocate(vmId, requestedIP string, addrOnly bool, maps []pod.UserContainerPort) (*Settings, error) {
 	return nil, fmt.Errorf("Generial Network driver is unsupported on this os")
 }
 
 // Release an interface for a select ip
-func Release(vmId, releasedIP string, index int, maps []pod.UserContainerPort, file *os.File) error {
+func Release(vmId, releasedIP string, maps []pod.UserContainerPort, file *os.File) error {
 	return fmt.Errorf("Generial Network driver is unsupported on this os")
 }

--- a/hypervisor/network/network_linux.go
+++ b/hypervisor/network/network_linux.go
@@ -32,9 +32,9 @@ const (
 )
 
 var (
-	native    binary.ByteOrder
-	nextSeqNr uint32
-	disableIptables	bool
+	native          binary.ByteOrder
+	nextSeqNr       uint32
+	disableIptables bool
 )
 
 type ifReq struct {
@@ -922,7 +922,7 @@ func UpAndAddToBridge(name string) error {
 	return nil
 }
 
-func Allocate(vmId, requestedIP string, index int, addrOnly bool, maps []pod.UserContainerPort) (*Settings, error) {
+func Allocate(vmId, requestedIP string, addrOnly bool, maps []pod.UserContainerPort) (*Settings, error) {
 	var (
 		req   ifReq
 		errno syscall.Errno
@@ -959,8 +959,7 @@ func Allocate(vmId, requestedIP string, index int, addrOnly bool, maps []pod.Use
 		}, nil
 	}
 
-	tapFile := new(os.File)
-	tapFile, err = os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
+	tapFile, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -1016,8 +1015,110 @@ func Allocate(vmId, requestedIP string, index int, addrOnly bool, maps []pod.Use
 	}, nil
 }
 
+func Configure(vmId, requestedIP string, addrOnly bool,
+	maps []pod.UserContainerPort, config pod.UserInterface) (*Settings, error) {
+	var (
+		req   ifReq
+		errno syscall.Errno
+	)
+
+	ip, ipnet, err := net.ParseCIDR(config.Ip)
+	if err != nil {
+		glog.Errorf("Parse config IP failed %s", err)
+		return nil, err
+	}
+
+	BridgeIface := config.Bridge
+	maskSize, _ := ipnet.Mask.Size()
+
+	err = SetupPortMaps(ip.String(), maps)
+	if err != nil {
+		glog.Errorf("Setup Port Map failed %s", err)
+		return nil, err
+	}
+
+	mac := config.Mac
+	if mac == "" {
+		mac, err = GenRandomMac()
+		if err != nil {
+			glog.Errorf("Generate Random Mac address failed")
+			return nil, err
+		}
+	}
+
+	if addrOnly {
+		return &Settings{
+			Mac:         mac,
+			IPAddress:   ip.String(),
+			Gateway:     config.Gw,
+			Bridge:      config.Bridge,
+			IPPrefixLen: maskSize,
+			Device:      "",
+			File:        nil,
+		}, nil
+	}
+
+	tapFile, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Flags = CIFF_TAP | CIFF_NO_PI | CIFF_ONE_QUEUE
+	if config.Ifname != "" {
+		copy(req.Name[:len(req.Name)-1], []byte(config.Ifname))
+	}
+	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, tapFile.Fd(),
+		uintptr(syscall.TUNSETIFF),
+		uintptr(unsafe.Pointer(&req)))
+	if errno != 0 {
+		err = fmt.Errorf("create tap device failed\n")
+		tapFile.Close()
+		return nil, err
+	}
+
+	device := strings.Trim(string(req.Name[:]), "\x00")
+
+	tapIface, err := net.InterfaceByName(device)
+	if err != nil {
+		glog.Errorf("get interface by name %s failed %s", device, err)
+		tapFile.Close()
+		return nil, err
+	}
+
+	bIface, err := net.InterfaceByName(BridgeIface)
+	if err != nil {
+		glog.Errorf("get interface by name %s failed", BridgeIface)
+		tapFile.Close()
+		return nil, err
+	}
+
+	err = AddToBridge(tapIface, bIface)
+	if err != nil {
+		glog.Errorf("Add to bridge failed %s %s", BridgeIface, device)
+		tapFile.Close()
+		return nil, err
+	}
+
+	err = NetworkLinkUp(tapIface)
+	if err != nil {
+		glog.Errorf("Link up device %s failed", tapIface)
+		tapFile.Close()
+		return nil, err
+	}
+
+	return &Settings{
+		Mac:         mac,
+		IPAddress:   ip.String(),
+		Gateway:     config.Gw,
+		Bridge:      BridgeIface,
+		IPPrefixLen: maskSize,
+		Device:      device,
+		File:        tapFile,
+	}, nil
+}
+
 // Release an interface for a select ip
-func Release(vmId, releasedIP string, index int, maps []pod.UserContainerPort, file *os.File) error {
+func Release(vmId, releasedIP string, maps []pod.UserContainerPort, file *os.File) error {
 	if file != nil {
 		file.Close()
 	}

--- a/hypervisor/network/network_linux.go
+++ b/hypervisor/network/network_linux.go
@@ -956,6 +956,7 @@ func Allocate(vmId, requestedIP string, addrOnly bool, maps []pod.UserContainerP
 			IPPrefixLen: maskSize,
 			Device:      "",
 			File:        nil,
+			Automatic:   true,
 		}, nil
 	}
 
@@ -1012,6 +1013,7 @@ func Allocate(vmId, requestedIP string, addrOnly bool, maps []pod.UserContainerP
 		IPPrefixLen: maskSize,
 		Device:      device,
 		File:        tapFile,
+		Automatic:   true,
 	}, nil
 }
 
@@ -1055,6 +1057,7 @@ func Configure(vmId, requestedIP string, addrOnly bool,
 			IPPrefixLen: maskSize,
 			Device:      "",
 			File:        nil,
+			Automatic:   false,
 		}, nil
 	}
 
@@ -1114,6 +1117,7 @@ func Configure(vmId, requestedIP string, addrOnly bool,
 		IPPrefixLen: maskSize,
 		Device:      device,
 		File:        tapFile,
+		Automatic:   false,
 	}, nil
 }
 

--- a/hypervisor/network/network_unsupported.go
+++ b/hypervisor/network/network_unsupported.go
@@ -6,10 +6,10 @@ func InitNetwork(bIface, bIP string, disableIptables bool) error {
 	return nil
 }
 
-func Allocate(vmId, requestedIP string, index int, addrOnly bool, maps []pod.UserContainerPort) (*Settings, error) {
+func Allocate(vmId, requestedIP string, addrOnly bool, maps []pod.UserContainerPort) (*Settings, error) {
 	return nil, nil
 }
 
-func Release(vmId, releasedIP string, index int, maps []pod.UserContainerPort, file *os.File) error {
+func Release(vmId, releasedIP string, maps []pod.UserContainerPort, file *os.File) error {
 	return nil
 }

--- a/hypervisor/pod.go
+++ b/hypervisor/pod.go
@@ -92,6 +92,7 @@ type VmPod struct {
 	Hostname   string         `json:"hostname"`
 	Containers []VmContainer  `json:"containers"`
 	Interfaces []VmNetworkInf `json:"interfaces,omitempty"`
+	Dns        []string       `json:"dns,omitempty"`
 	Routes     []VmRoute      `json:"routes,omitempty"`
 	ShareDir   string         `json:"shareDir"`
 }

--- a/hypervisor/pod/pod.go
+++ b/hypervisor/pod/pod.go
@@ -186,6 +186,17 @@ func (pod *UserPod) Validate() error {
 		"rbd":   true,
 	}
 
+	hasGw := false
+	for idx, config := range pod.Interfaces {
+		if config.Gw == "" {
+			continue
+		}
+		if hasGw {
+			return fmt.Errorf("in interface %d, Other interface already configured Gateway", idx)
+		}
+		hasGw = true
+	}
+
 	uniq, vset := keySet(pod.Volumes)
 	if !uniq {
 		if len(vset) > 0 {

--- a/hypervisor/pod/pod.go
+++ b/hypervisor/pod/pod.go
@@ -76,12 +76,22 @@ type UserVolume struct {
 	Option UserVolumeOption `json:"option,omitempty"`
 }
 
+type UserInterface struct {
+	Bridge string `json:"bridge"`
+	Ip     string `json:"ip"`
+	Ifname string `json:"ifname,omitempty"`
+	Mac    string `json:"mac,omitempty"`
+	Gw     string `json:"gateway,omitempty"`
+}
+
 type UserPod struct {
 	Name          string          `json:"id"`
 	Containers    []UserContainer `json:"containers"`
 	Resource      UserResource    `json:"resource"`
 	Files         []UserFile      `json:"files"`
 	Volumes       []UserVolume    `json:"volumes"`
+	Interfaces    []UserInterface `json:"interfaces,omitempty"`
+	Dns           []string        `json:"dns,omitempty"`
 	Tty           bool            `json:"tty"`
 	Type          string          `json:"type"`
 	RestartPolicy string

--- a/hypervisor/qemu/network.go
+++ b/hypervisor/qemu/network.go
@@ -15,6 +15,11 @@ func (qd *QemuDriver) InitNetwork(bIface, bIP string) error {
 	return nil
 }
 
+func (qc *QemuContext) ConfigureNetwork(vmId, requestedIP string,
+	maps []pod.UserContainerPort, config pod.UserInterface) (*network.Settings, error) {
+	return nil, nil
+}
+
 func (qc *QemuContext) AllocateNetwork(vmId, requestedIP string,
 	maps []pod.UserContainerPort) (*network.Settings, error) {
 	return nil, nil

--- a/hypervisor/xen/network.go
+++ b/hypervisor/xen/network.go
@@ -11,8 +11,13 @@ func (xd *XenDriver) BuildinNetwork() bool {
 	return false
 }
 
-func (xd *XenDriver) InitNetwork(bIface, bIP string) (error) {
+func (xd *XenDriver) InitNetwork(bIface, bIP string) error {
 	return nil
+}
+
+func (xc *XenContext) ConfigureNetwork(vmId, requestedIP string,
+	maps []pod.UserContainerPort, config pod.UserInterface) (*network.Settings, error) {
+	return nil, nil
 }
 
 func (xc *XenContext) AllocateNetwork(vmId, requestedIP string,


### PR DESCRIPTION
work together with hyperstart patch `https://github.com/hyperhq/hyperstart/pull/2`

```
{
"interfaces": [{
    "bridge": "qbr-aaaa",
    "Ifname": "tap-aaaa",
    "ip": "10.10.0.8/24",
    "gw":"10.10.0.1"
},
{
    "bridge": "qbr-bbbb",
    "mac": "52:54:c3:14:59:46",
    "ip": "192.168.2.2/24"
}],
"dns": ["114.114.114.114", "8.8.8.8"]
}