### PR TITLE
remove the dependence of godep

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,8 +12,8 @@ install-exec-local:
 	$(INSTALL_PROGRAM) runv $(bindir)
 if ON_DARWIN
 build-runv:
-	godep go build -tags "static_build $(HYPER_BULD_TAGS)" runv.go runv_darwin.go
+	go build -tags "static_build $(HYPER_BULD_TAGS)" runv.go runv_darwin.go
 else
 build-runv:
-	godep go build -tags "static_build $(HYPER_BULD_TAGS)" runv.go runv_linux.go
+	go build -tags "static_build $(HYPER_BULD_TAGS)" runv.go runv_linux.go
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -26,11 +26,6 @@ if test "x$has_go" != "xyes" ; then
     AC_MSG_ERROR(Unable to find go binary in PATH)
 fi
 
-AC_CHECK_PROG([has_godep], [godep], [yes], [no])
-if test "x$has_godep" != "xyes" ; then
-    AC_MSG_ERROR(Unable to find godep binary in PATH)
-fi
-
 AC_CHECK_PROG([has_sqlite3], [sqlite3], [yes], [no])
 if test "x$has_sqlite3" != "xyes" ; then
     AC_MSG_ERROR(Unable to find sqlite3 binary in PATH)
@@ -101,7 +96,6 @@ AC_MSG_RESULT([
 	prefix:	    ${prefix}
 
 	has go:     ${has_go}
-	has godep:  ${has_go}
 
 	with xen:   ${with_xen}
 


### PR DESCRIPTION
The path Godeps/_workspace/ is added to GOPATH when build.
so godep itself doesn't be required for build,  remove it.

Note1: godep is still needed for the developers who want to
update the Godeps/
Note2: the golang will have offical vendor support
in the near future.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>