### PR TITLE
portable shell function definition in case /bin/sh is not bash

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,7 +5,7 @@ test -z "$srcdir" && srcidr=.
 
 cd $srcdir
 
-function die
+die()
 {
 	echo
 	echo "$1"


### PR DESCRIPTION
autogen.sh does not currently build on Debian/Ubuntu as uses bash specific syntax