### PR TITLE
Init tty connection before container run

### DIFF
--- a/hypervisor/pod/ocf_linux.go
+++ b/hypervisor/pod/ocf_linux.go
@@ -18,7 +18,7 @@ func OCFConvert2Pod(ociData []byte, runtimeData []byte) (*UserPod, error) {
 		if err := json.Unmarshal(runtimeData, &r); err != nil {
 			return nil, err
 		}
-		memory = int(r.Linux.Resources.Memory.Limit>>20)
+		memory = int(r.Linux.Resources.Memory.Limit >> 20)
 	}
 
 	return OCFSpec2Pod(s.Spec, memory), nil


### PR DESCRIPTION
originally we start pod, then attach tty to it. Then we may miss
the beginning of the tty output. Even miss all the output if the
progress exit at once.

this patch include the hyper part and runv part, to enable
establishing the tty connection before starting pod. The result
will be like:

    gnawux@sonic$ ./hyper run busybox ps aux
    PID   USER     COMMAND
        1 root     /init
        2 root     ps aux
    Successfully attached to pod(pod-xhZAmXwXCV)
    End of CmdExec(), Waiting for hijack to finish.
    POD id is pod-xhZAmXwXCV

This is required by hyper pr 84

Signed-off-by: Wang Xu <gnawux@gmail.com>