### PR TITLE
add support of separate stderr output of container

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -298,11 +298,12 @@ func (ctx *VmContext) InitDeviceContext(spec *pod.UserPod, wg *sync.WaitGroup,
 		ctx.initContainerInfo(i, &containers[i], &container)
 		ctx.setContainerInfo(i, &containers[i], cInfo[i])
 
-		if spec.Tty {
-			containers[i].Tty = ctx.attachId
-			ctx.attachId++
-			ctx.ptys.ttys[containers[i].Tty] = newAttachments(i, true)
-		}
+		containers[i].Tty = ctx.attachId
+		ctx.attachId++
+		containers[i].Stderr = ctx.attachId
+		ctx.attachId++
+		ctx.ptys.ttys[containers[i].Tty] = newAttachments(i, true)
+		ctx.ptys.ttys[containers[i].Stderr] = newAttachments(i, true)
 	}
 
 	hostname := spec.Name

--- a/hypervisor/devicemap.go
+++ b/hypervisor/devicemap.go
@@ -115,7 +115,7 @@ func (ctx *VmContext) initContainerInfo(index int, target *VmContainer, spec *po
 
 	*target = VmContainer{
 		Id: "", Rootfs: "rootfs", Fstype: "", Image: "",
-		Volumes: vols, Fsmap: fsmap, Tty: 0,
+		Volumes: vols, Fsmap: fsmap, Tty: 0, Stderr: 0,
 		Workdir: spec.Workdir, Entrypoint: spec.Entrypoint, Cmd: spec.Command, Envs: envs,
 		RestartPolicy: restart,
 	}

--- a/hypervisor/events.go
+++ b/hypervisor/events.go
@@ -75,6 +75,7 @@ type ReleaseVMCommand struct{}
 type AttachCommand struct {
 	Container string
 	Streams   *TtyIO
+	Stderr    *TtyIO
 	Size      *WindowSize
 }
 

--- a/hypervisor/persistence.go
+++ b/hypervisor/persistence.go
@@ -185,6 +185,7 @@ func (pinfo *PersistInfo) vmContext(hub chan VmEvent, client chan *types.VmRespo
 
 	for idx, container := range ctx.vmSpec.Containers {
 		ctx.ptys.ttys[container.Tty] = newAttachments(idx, true)
+		ctx.ptys.ttys[container.Stderr] = newAttachments(idx, true)
 	}
 
 	for _, vol := range pinfo.VolumeList {

--- a/hypervisor/pod.go
+++ b/hypervisor/pod.go
@@ -69,6 +69,7 @@ type VmContainer struct {
 	Volumes       []VmVolumeDescriptor `json:"volumes,omitempty"`
 	Fsmap         []VmFsmapDescriptor  `json:"fsmap,omitempty"`
 	Tty           uint64               `json:"tty,omitempty"`
+	Stderr        uint64               `json:"stderr,omitempty"`
 	Workdir       string               `json:"workdir"`
 	Entrypoint    []string             `json:"-"`
 	Cmd           []string             `json:"cmd"`

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -186,6 +186,7 @@ func (ctx *VmContext) attachTty2Container(idx int, cmd *AttachCommand) {
 				Stdout:    cmd.Streams.Stdout,
 				ClientTag: cmd.Streams.ClientTag,
 				Callback:  nil,
+				liner:     &linerTransformer{},
 			}
 		}
 		ctx.ptys.ptyConnect(ctx, idx, session, stderrIO)

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -59,20 +59,16 @@ func (ctx *VmContext) prepareDevice(cmd *RunPodCommand) bool {
 		glog.Info("initial vm spec: ", string(res))
 	}
 
-	if cmd.Spec.Tty {
-		pendings := ctx.pendingTtys
-		ctx.pendingTtys = []*AttachCommand{}
-		for _, acmd := range pendings {
-			idx := ctx.Lookup(acmd.Container)
-			if idx >= 0 {
-				session := ctx.vmSpec.Containers[idx].Tty
-				ctx.ptys.ptyConnect(ctx, idx, session, acmd.Streams)
-				ctx.clientReg(acmd.Streams.ClientTag, session)
-				glog.Infof("attach pending client %s for %s", acmd.Streams.ClientTag, acmd.Container)
-			} else {
-				glog.Infof("not attach %s for %s", acmd.Streams.ClientTag, acmd.Container)
-				ctx.pendingTtys = append(ctx.pendingTtys, acmd)
-			}
+	pendings := ctx.pendingTtys
+	ctx.pendingTtys = []*AttachCommand{}
+	for _, acmd := range pendings {
+		idx := ctx.Lookup(acmd.Container)
+		if idx >= 0 {
+			glog.Infof("attach pending client %s for %s", acmd.Streams.ClientTag, acmd.Container)
+			ctx.attachTty2Container(idx, acmd)
+		} else {
+			glog.Infof("not attach %s for %s", acmd.Streams.ClientTag, acmd.Container)
+			ctx.pendingTtys = append(ctx.pendingTtys, acmd)
 		}
 	}
 
@@ -168,12 +164,31 @@ func (ctx *VmContext) attachCmd(cmd *AttachCommand) {
 		}
 		return
 	}
-	session := ctx.vmSpec.Containers[idx].Tty
-	glog.V(1).Infof("Connecting tty for %s on session %d", cmd.Container, session)
-	ctx.ptys.ptyConnect(ctx, idx, session, cmd.Streams)
-	ctx.clientReg(cmd.Streams.ClientTag, session)
+	ctx.attachTty2Container(idx, cmd)
 	if cmd.Size != nil {
 		ctx.setWindowSize(cmd.Streams.ClientTag, cmd.Size)
+	}
+}
+
+func (ctx *VmContext) attachTty2Container(idx int, cmd *AttachCommand) {
+	session := ctx.vmSpec.Containers[idx].Tty
+	ctx.ptys.ptyConnect(ctx, idx, session, cmd.Streams)
+	ctx.clientReg(cmd.Streams.ClientTag, session)
+	glog.V(1).Infof("Connecting tty for %s on session %d", cmd.Container, session)
+
+	//new stderr session
+	session = ctx.vmSpec.Containers[idx].Stderr
+	if session > 0 {
+		stderrIO := cmd.Stderr
+		if stderrIO == nil {
+			stderrIO = &TtyIO{
+				Stdin:     nil,
+				Stdout:    cmd.Streams.Stdout,
+				ClientTag: cmd.Streams.ClientTag,
+				Callback:  nil,
+			}
+		}
+		ctx.ptys.ptyConnect(ctx, idx, session, stderrIO)
 	}
 }
 


### PR DESCRIPTION
this patch add a pipe besides the pty for container, and the stderr will be
sent from the stderr session if the session provided in spec.

this intend to support log the stdout and stderr separately.