### PR TITLE
only create stderr seq for those non-interactive pod

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -300,10 +300,12 @@ func (ctx *VmContext) InitDeviceContext(spec *pod.UserPod, wg *sync.WaitGroup,
 
 		containers[i].Tty = ctx.attachId
 		ctx.attachId++
-		containers[i].Stderr = ctx.attachId
-		ctx.attachId++
 		ctx.ptys.ttys[containers[i].Tty] = newAttachments(i, true)
-		ctx.ptys.ttys[containers[i].Stderr] = newAttachments(i, true)
+		if !spec.Tty {
+			containers[i].Stderr = ctx.attachId
+			ctx.attachId++
+			ctx.ptys.ttys[containers[i].Stderr] = newAttachments(i, true)
+		}
 	}
 
 	hostname := spec.Name

--- a/hypervisor/persistence.go
+++ b/hypervisor/persistence.go
@@ -185,7 +185,9 @@ func (pinfo *PersistInfo) vmContext(hub chan VmEvent, client chan *types.VmRespo
 
 	for idx, container := range ctx.vmSpec.Containers {
 		ctx.ptys.ttys[container.Tty] = newAttachments(idx, true)
-		ctx.ptys.ttys[container.Stderr] = newAttachments(idx, true)
+		if container.Stderr > 0 {
+			ctx.ptys.ttys[container.Stderr] = newAttachments(idx, true)
+		}
 	}
 
 	for _, vol := range pinfo.VolumeList {


### PR DESCRIPTION
then for shells, it can work in interactive mode. and for daemons, they can output stdout and stderr to different log streams.