### PR TITLE
close client channel when close vm context

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -232,6 +232,7 @@ func (ctx *VmContext) Close() {
 	ctx.unsetTimeout()
 	ctx.DCtx.Close()
 	close(ctx.vm)
+	close(ctx.client)
 	os.Remove(ctx.ShareDir)
 	ctx.handler = nil
 	ctx.current = "None"


### PR DESCRIPTION
this will lead to close the fanout, and then close all channel listened this.
in normal case, this affects nothing, but in case vm doesn't start normally,
this may help to avoiding dead wait the pod running
