### PR TITLE
Cleanup

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -37,15 +37,15 @@ var execCommand = cli.Command{
 }
 
 func execProcess(context *cli.Context, config *specs.Process) (int, error) {
-	podId := context.GlobalString("id")
+	container := context.GlobalString("id")
 	root := context.GlobalString("root")
-	podPath := path.Join(root, podId)
+	stateDir := path.Join(root, container)
 
-	if podId == "" {
-		return -1, fmt.Errorf("Please specify container")
+	if container == "" {
+		return -1, fmt.Errorf("Please specify container ID")
 	}
 
-	conn, err := net.Dial("unix", path.Join(podPath, "runv.sock"))
+	conn, err := net.Dial("unix", path.Join(stateDir, "runv.sock"))
 	if err != nil {
 		return -1, err
 	}
@@ -100,7 +100,7 @@ func execProcess(context *cli.Context, config *specs.Process) (int, error) {
 		sendStdin <- nil
 	}()
 
-	newTty(nil, podPath, tag, outFd, isTerminalOut).monitorTtySize()
+	newTty(nil, stateDir, tag, outFd, isTerminalOut).monitorTtySize()
 
 	if err := <-receiveStdout; err != nil {
 		return -1, err

--- a/tty.go
+++ b/tty.go
@@ -14,11 +14,11 @@ import (
 )
 
 type tty struct {
-	vm           *hypervisor.Vm
-	containerDir string
-	tag          string
-	termFd       uintptr
-	terminal     bool
+	vm       *hypervisor.Vm
+	stateDir string
+	tag      string
+	termFd   uintptr
+	terminal bool
 }
 
 type ttyWinSize struct {
@@ -27,13 +27,13 @@ type ttyWinSize struct {
 	Width  int
 }
 
-func newTty(vm *hypervisor.Vm, containerDir string, tag string, termFd uintptr, terminal bool) *tty {
+func newTty(vm *hypervisor.Vm, stateDir string, tag string, termFd uintptr, terminal bool) *tty {
 	return &tty{
-		vm:           vm,
-		containerDir: containerDir,
-		tag:          tag,
-		termFd:       termFd,
-		terminal:     terminal,
+		vm:       vm,
+		stateDir: stateDir,
+		tag:      tag,
+		termFd:   termFd,
+		terminal: terminal,
 	}
 }
 
@@ -48,7 +48,7 @@ func (tty *tty) resizeTty() {
 		return
 	}
 
-	conn, err := net.Dial("unix", path.Join(tty.containerDir, "runv.sock"))
+	conn, err := net.Dial("unix", path.Join(tty.stateDir, "runv.sock"))
 	if err != nil {
 		fmt.Printf("resize dial fail\n")
 		return //TODO


### PR DESCRIPTION

rename podId to container

The podId, podPath are for container when old simple container
implementation, we will enable multiple containers. So the renaming
is required.

podId -> container
podPath -> stateDir
containerDir -> stateDir
save container ID in state file

