### PR TITLE
get right response of request

### DIFF
--- a/hypervisor/events.go
+++ b/hypervisor/events.go
@@ -85,14 +85,11 @@ type AttachCommand struct {
 }
 
 type CommandAck struct {
-	reply uint32
+	reply *DecodedMessage
 	msg   []byte
 }
 
-type CommandError struct {
-	context *DecodedMessage
-	msg     []byte
-}
+type CommandError CommandAck
 
 type WindowSizeCommand struct {
 	ClientTag string

--- a/hypervisor/init_comm.go
+++ b/hypervisor/init_comm.go
@@ -15,6 +15,7 @@ import (
 type DecodedMessage struct {
 	Code    uint32
 	Message []byte
+	Event   VmEvent
 }
 
 type FinishCmd struct {
@@ -173,14 +174,14 @@ func waitCmdToInit(ctx *VmContext, init *net.UnixConn) {
 				if cmd.Code == INIT_ACK {
 					if cmds[0].Code != INIT_PING {
 						ctx.Hub <- &CommandAck{
-							reply: cmds[0].Code,
+							reply: cmds[0],
 							msg:   cmd.Message,
 						}
 					}
 				} else {
 					ctx.Hub <- &CommandError{
-						context: cmds[0],
-						msg:     cmd.Message,
+						reply: cmds[0],
+						msg:   cmd.Message,
 					}
 				}
 				cmds = cmds[1:]
@@ -218,7 +219,7 @@ func waitCmdToInit(ctx *VmContext, init *net.UnixConn) {
 					glog.Info("got pod finish message after having send destroy message")
 					looping = false
 					ctx.Hub <- &CommandAck{
-						reply: c.Code,
+						reply: c,
 					}
 					break
 				}

--- a/hypervisor/lazy.go
+++ b/hypervisor/lazy.go
@@ -69,7 +69,7 @@ func statePreparing(ctx *VmContext, ev VmEvent) {
 			ctx.Become(nil, "None")
 		}
 	default:
-		glog.Warning("got event during pod initiating")
+		unexpectedEventHandler(ctx, ev, "pod initiating")
 	}
 }
 

--- a/hypervisor/pod.go
+++ b/hypervisor/pod.go
@@ -179,7 +179,7 @@ func (mypod *PodStatus) GetPodIP(vm *Vm) []string {
 	for {
 		response = <-Status
 		glog.V(1).Infof("Got response, Code %d, VM id %s!", response.Code, response.VmId)
-		if response.Code != types.E_POD_IP {
+		if response.Reply != getPodIPEvent {
 			continue
 		}
 		if response.VmId == vm.Id {

--- a/hypervisor/report.go
+++ b/hypervisor/report.go
@@ -85,6 +85,16 @@ func (ctx *VmContext) reportBadRequest(cause string) {
 	}
 }
 
+// reportUnexpectedRequest send report to daemon, notify about that:
+//   1. unexpected event in current state
+func (ctx *VmContext) reportUnexpectedRequest(state string) {
+	ctx.client <- &types.VmResponse{
+		VmId:  ctx.Id,
+		Code:  types.E_UNEXPECTED,
+		Cause: "unexpected event during " + state,
+	}
+}
+
 // reportVmFault send report to daemon, notify about that:
 //   1. vm op failed due to some reason described in `cause`
 func (ctx *VmContext) reportVmFault(cause string) {

--- a/hypervisor/report.go
+++ b/hypervisor/report.go
@@ -139,11 +139,12 @@ func (ctx *VmContext) reportPodIP() {
 	}
 }
 
-func (ctx *VmContext) reportFile(code uint32, data []byte, err bool) {
+func (ctx *VmContext) reportFile(reply VmEvent, code uint32, data []byte, err bool) {
 	response := &types.VmResponse{
 		VmId:  ctx.Id,
 		Code:  types.E_WRITEFILE,
 		Cause: "",
+		Reply: reply,
 		Data:  data,
 	}
 
@@ -152,11 +153,9 @@ func (ctx *VmContext) reportFile(code uint32, data []byte, err bool) {
 		if err {
 			response.Cause = "readfile failed"
 		}
-		ctx.client <- response
-	} else {
-		if err == true {
-			response.Cause = "writefile failed"
-		}
-		ctx.client <- response
+	} else if err == true {
+		response.Cause = "writefile failed"
 	}
+
+	ctx.client <- response
 }

--- a/hypervisor/report.go
+++ b/hypervisor/report.go
@@ -123,7 +123,7 @@ func (ctx *VmContext) reportExec(ev VmEvent, fail bool) {
 	ctx.client <- response
 }
 
-func (ctx *VmContext) reportPodIP() {
+func (ctx *VmContext) reportPodIP(ev VmEvent) {
 	ips := []string{}
 	for _, i := range ctx.vmSpec.Interfaces {
 		if i.Device == "lo" {
@@ -135,6 +135,7 @@ func (ctx *VmContext) reportPodIP() {
 		VmId:  ctx.Id,
 		Code:  types.E_POD_IP,
 		Cause: "",
+		Reply: ev,
 		Data:  ips,
 	}
 }

--- a/hypervisor/report.go
+++ b/hypervisor/report.go
@@ -87,10 +87,11 @@ func (ctx *VmContext) reportBadRequest(cause string) {
 
 // reportUnexpectedRequest send report to daemon, notify about that:
 //   1. unexpected event in current state
-func (ctx *VmContext) reportUnexpectedRequest(state string) {
+func (ctx *VmContext) reportUnexpectedRequest(ev VmEvent, state string) {
 	ctx.client <- &types.VmResponse{
 		VmId:  ctx.Id,
 		Code:  types.E_UNEXPECTED,
+		Reply: ev,
 		Cause: "unexpected event during " + state,
 	}
 }
@@ -103,6 +104,23 @@ func (ctx *VmContext) reportVmFault(cause string) {
 		Code:  types.E_FAILED,
 		Cause: cause,
 	}
+}
+
+// reportExec send report to daemon, notify about that:
+//   1. exec status
+func (ctx *VmContext) reportExec(ev VmEvent, fail bool) {
+	response := &types.VmResponse{
+		VmId:  ctx.Id,
+		Code:  types.E_EXEC_FINISH,
+		Reply: ev,
+		Cause: "",
+	}
+
+	if fail {
+		response.Cause = "exec failed"
+	}
+
+	ctx.client <- response
 }
 
 func (ctx *VmContext) reportPodIP() {

--- a/hypervisor/types/types.go
+++ b/hypervisor/types/types.go
@@ -41,5 +41,6 @@ type VmResponse struct {
 	VmId  string
 	Code  int
 	Cause string
+	Reply interface{}
 	Data  interface{}
 }

--- a/hypervisor/types/types.go
+++ b/hypervisor/types/types.go
@@ -16,6 +16,7 @@ const (
 	E_POD_IP
 	E_WRITEFILE
 	E_READFILE
+	E_UNEXPECTED
 )
 
 // status for POD or container

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -169,6 +169,7 @@ func (ctx *VmContext) writeFile(cmd *WriteFileCommand) {
 	ctx.vm <- &DecodedMessage{
 		Code:    INIT_WRITEFILE,
 		Message: writeCmd,
+		Event:   cmd,
 	}
 }
 
@@ -183,6 +184,7 @@ func (ctx *VmContext) readFile(cmd *ReadFileCommand) {
 	ctx.vm <- &DecodedMessage{
 		Code:    INIT_READFILE,
 		Message: readCmd,
+		Event:   cmd,
 	}
 }
 
@@ -585,10 +587,10 @@ func stateRunning(ctx *VmContext, ev VmEvent) {
 				ctx.reportExec(ack.reply.Event, false)
 				glog.Infof("Get ack for exec cmd")
 			} else if ack.reply.Code == INIT_READFILE {
-				ctx.reportFile(INIT_READFILE, ack.msg, false)
+				ctx.reportFile(ack.reply.Event, INIT_READFILE, ack.msg, false)
 				glog.Infof("Get ack for read data: %s", string(ack.msg))
 			} else if ack.reply.Code == INIT_WRITEFILE {
-				ctx.reportFile(INIT_WRITEFILE, ack.msg, false)
+				ctx.reportFile(ack.reply.Event, INIT_WRITEFILE, ack.msg, false)
 				glog.Infof("Get ack for write data: %s", string(ack.msg))
 			}
 		case ERROR_CMD_FAIL:
@@ -599,10 +601,10 @@ func stateRunning(ctx *VmContext, ev VmEvent) {
 				ctx.reportExec(ack.reply.Event, true)
 				glog.V(0).Infof("Exec command %s on session %d failed", cmd.Command[0], cmd.Sequence)
 			} else if ack.reply.Code == INIT_READFILE {
-				ctx.reportFile(INIT_READFILE, ack.msg, true)
+				ctx.reportFile(ack.reply.Event, INIT_READFILE, ack.msg, true)
 				glog.Infof("Get error for read data: %s", string(ack.msg))
 			} else if ack.reply.Code == INIT_WRITEFILE {
-				ctx.reportFile(INIT_WRITEFILE, ack.msg, true)
+				ctx.reportFile(ack.reply.Event, INIT_WRITEFILE, ack.msg, true)
 				glog.Infof("Get error for write data: %s", string(ack.msg))
 			}
 

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -470,7 +470,7 @@ func stateInit(ctx *VmContext, ev VmEvent) {
 				ctx.Become(stateStarting, "STARTING")
 			}
 		case COMMAND_GET_POD_IP:
-			ctx.reportPodIP()
+			ctx.reportPodIP(ev)
 		default:
 			unexpectedEventHandler(ctx, ev, "pod initiating")
 		}
@@ -609,7 +609,7 @@ func stateRunning(ctx *VmContext, ev VmEvent) {
 			}
 
 		case COMMAND_GET_POD_IP:
-			ctx.reportPodIP()
+			ctx.reportPodIP(ev)
 		default:
 			unexpectedEventHandler(ctx, ev, "pod running")
 		}

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -603,7 +603,11 @@ func statePodStopping(ctx *VmContext, ev VmEvent) {
 			ctx.shutdownVM(false, "got release, quit")
 			ctx.Become(stateTerminating, "TERMINATING")
 			ctx.reportVmShutdown()
-		case COMMAND_ACK, EVENT_POD_FINISH:
+		case EVENT_POD_FINISH:
+			glog.Info("POD stopped")
+			ctx.detachDevice()
+			ctx.Become(stateCleaning, "CLEANING")
+		case COMMAND_ACK:
 			ack := ev.(*CommandAck)
 			glog.V(1).Infof("[Stopping] got init ack to %d", ack.reply)
 			if ack.reply == INIT_STOPPOD {


### PR DESCRIPTION
1,the vm state machine doesn't handle unexpected event(request), there will be no response to this request, this will cause the caller blocked to waiting for response.
first patch fixs this by sending unexpected response to request if request needs

2, right now we don't check if exec event is handled correctly. the second patch add this check, so we don't try to read stream callback if exec event failed. And other events get response through response chan, this patch makes exec event consist with other events. This patch also introduces Replyto field to
Vmresponse, with this field, request can check if the response is what it expected.

3, Fix possible getting incorrect response for read/write file event

TODO: Fix possible getting incorrect response for RunPod,StopPod events