### PR TITLE
Shared namespaces multiple containers support

### DIFF
--- a/hypervisor/pod/ocf-linux.go
+++ b/hypervisor/pod/ocf-linux.go
@@ -1,15 +1,14 @@
 package pod
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/opencontainers/specs"
 )
 
-func ConvertOCFLinuxContainer(s specs.LinuxSpec, r specs.LinuxRuntimeSpec) UserContainer {
-	container := UserContainer{
+func ConvertOCF2UserContainer(s *specs.LinuxSpec, r *specs.LinuxRuntimeSpec) *UserContainer {
+	container := &UserContainer{
 		Command:       s.Spec.Process.Args,
 		Workdir:       s.Spec.Process.Cwd,
 		Tty:           s.Spec.Process.Terminal,
@@ -31,34 +30,15 @@ func ConvertOCFLinuxContainer(s specs.LinuxSpec, r specs.LinuxRuntimeSpec) UserC
 	return container
 }
 
-func ParseOCFLinuxContainerConfig(ociData []byte, runtimeData []byte) (*UserPod, *specs.RuntimeSpec, error) {
-	var s specs.LinuxSpec
-	var r specs.LinuxRuntimeSpec
-
-	if err := json.Unmarshal(ociData, &s); err != nil {
-		return nil, nil, err
-	}
-
-	if err := json.Unmarshal(runtimeData, &r); err != nil {
-		return nil, nil, err
-	}
-	memory := int(r.Linux.Resources.Memory.Limit >> 20)
-
-	userpod := &UserPod{
+func ConvertOCF2PureUserPod(s *specs.LinuxSpec, r *specs.LinuxRuntimeSpec) *UserPod {
+	return &UserPod{
 		Name: s.Spec.Hostname,
 		Resource: UserResource{
-			Memory: memory,
+			Memory: int(r.Linux.Resources.Memory.Limit >> 20),
 			Vcpu:   0,
 		},
 		Tty:           s.Spec.Process.Terminal,
 		Type:          "OCF",
 		RestartPolicy: "never",
 	}
-
-	userpod.Containers = append(userpod.Containers, ConvertOCFLinuxContainer(s, r))
-
-	userData, _ := json.Marshal(userpod)
-	fmt.Printf("userData:\n%s\n", userData)
-
-	return userpod, &r.RuntimeSpec, nil
 }

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 		startCommand,
 		specCommand,
 		execCommand,
+		daemonCommand,
 	}
 	if err := app.Run(os.Args); err != nil {
 		fmt.Printf("%s\n", err.Error())

--- a/ns-daemon.go
+++ b/ns-daemon.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/codegangsta/cli"
+)
+
+// TODO: logging for daemon
+
+var daemonCommand = cli.Command{
+	Name:  "daemon",
+	Usage: "internal and hidden daemon command, run in daemon mode",
+	Action: func(context *cli.Context) {
+		startVContainer(context.GlobalString("root"), context.GlobalString("id"))
+	},
+	HideHelp: true,
+}

--- a/ns-daemon.go
+++ b/ns-daemon.go
@@ -20,6 +20,7 @@ type nsContext struct {
 	vm          *hypervisor.Vm
 	firstConfig *startConfig
 	actives     map[string]*startConfig
+	wg          sync.WaitGroup
 }
 
 var daemonCommand = cli.Command{
@@ -29,6 +30,7 @@ var daemonCommand = cli.Command{
 		context := &nsContext{}
 		context.actives = make(map[string]*startConfig)
 		startVContainer(context, cliContext.GlobalString("root"), cliContext.GlobalString("id"))
+		context.wg.Wait()
 	},
 	HideHelp: true,
 }

--- a/ns-daemon.go
+++ b/ns-daemon.go
@@ -2,15 +2,27 @@ package main
 
 import (
 	"github.com/codegangsta/cli"
+	"github.com/hyperhq/runv/hypervisor"
+	"github.com/hyperhq/runv/hypervisor/pod"
 )
 
 // TODO: logging for daemon
 
+// namespace context for runv daemon
+type nsContext struct {
+	podId     string
+	vmId      string
+	userPod   *pod.UserPod
+	podStatus *hypervisor.PodStatus
+	vm        *hypervisor.Vm
+}
+
 var daemonCommand = cli.Command{
 	Name:  "daemon",
 	Usage: "internal and hidden daemon command, run in daemon mode",
-	Action: func(context *cli.Context) {
-		startVContainer(context.GlobalString("root"), context.GlobalString("id"))
+	Action: func(cliContext *cli.Context) {
+		context := &nsContext{}
+		startVContainer(context, cliContext.GlobalString("root"), cliContext.GlobalString("id"))
 	},
 	HideHelp: true,
 }

--- a/ns-daemon.go
+++ b/ns-daemon.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"sync"
+
 	"github.com/codegangsta/cli"
 	"github.com/hyperhq/runv/hypervisor"
 	"github.com/hyperhq/runv/hypervisor/pod"
@@ -10,11 +12,14 @@ import (
 
 // namespace context for runv daemon
 type nsContext struct {
-	podId     string
-	vmId      string
-	userPod   *pod.UserPod
-	podStatus *hypervisor.PodStatus
-	vm        *hypervisor.Vm
+	lock        sync.Mutex
+	podId       string
+	vmId        string
+	userPod     *pod.UserPod
+	podStatus   *hypervisor.PodStatus
+	vm          *hypervisor.Vm
+	firstConfig *startConfig
+	actives     map[string]*startConfig
 }
 
 var daemonCommand = cli.Command{
@@ -22,6 +27,7 @@ var daemonCommand = cli.Command{
 	Usage: "internal and hidden daemon command, run in daemon mode",
 	Action: func(cliContext *cli.Context) {
 		context := &nsContext{}
+		context.actives = make(map[string]*startConfig)
 		startVContainer(context, cliContext.GlobalString("root"), cliContext.GlobalString("id"))
 	},
 	HideHelp: true,

--- a/runv.go
+++ b/runv.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	_ = iota
+	RUNV_INITCONTAINER
 	RUNV_STARTCONTAINER
 	RUNV_ACK
 	RUNV_EXECCMD
@@ -440,6 +441,16 @@ func HandleRunvRequest(context *nsContext, info *hypervisor.ContainerInfo, conn 
 	}
 
 	switch msg.Code {
+	case RUNV_INITCONTAINER:
+		{
+			initCmd := &initContainerCmd{}
+			err = json.Unmarshal(msg.Message, initCmd)
+			if err != nil {
+				fmt.Printf("parse runv init container command failed: %v\n", err)
+				return
+			}
+			startVContainer(context, initCmd.Root, initCmd.Name)
+		}
 	case RUNV_EXECCMD:
 		{
 			tag, _ := runvAllocAndRespondTag(conn)

--- a/start.go
+++ b/start.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/opencontainers/specs"
+)
+
+type startConfig struct {
+	Name       string
+	BundlePath string
+	Root       string
+	Driver     string
+	Kernel     string
+	Initrd     string
+	Vbox       string
+	specs.LinuxSpec
+	specs.LinuxRuntimeSpec
+}
+
+func loadStartConfig(context *cli.Context) (*startConfig, error) {
+	config := &startConfig{
+		Name:   context.GlobalString("id"),
+		Root:   context.GlobalString("root"),
+		Driver: context.GlobalString("driver"),
+		Kernel: context.GlobalString("kernel"),
+		Initrd: context.GlobalString("initrd"),
+		Vbox:   context.GlobalString("vbox"),
+	}
+
+	if config.Name == "" {
+		return nil, fmt.Errorf("Please specify container ID")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	config.BundlePath = cwd
+
+	ocffile := context.String("config-file")
+	runtimefile := context.String("runtime-file")
+
+	if _, err := os.Stat(ocffile); os.IsNotExist(err) {
+		fmt.Printf("Please specify ocffile or put config.json under current working directory\n")
+		return nil, err
+	}
+
+	ocfData, err := ioutil.ReadFile(ocffile)
+	if err != nil {
+		fmt.Printf("%s\n", err.Error())
+		return nil, err
+	}
+
+	var runtimeData []byte = nil
+	_, err = os.Stat(runtimefile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Printf("Fail to stat %s, %s\n", runtimefile, err.Error())
+			return nil, err
+		}
+	} else {
+		runtimeData, err = ioutil.ReadFile(runtimefile)
+		if err != nil {
+			fmt.Printf("Fail to readfile %s, %s\n", runtimefile, err.Error())
+			return nil, err
+		}
+	}
+
+	if err := json.Unmarshal(ocfData, &config.LinuxSpec); err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(runtimeData, &config.LinuxRuntimeSpec); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+var startCommand = cli.Command{
+	Name:  "start",
+	Usage: "create and run a container",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "config-file, c",
+			Value: "config.json",
+			Usage: "path to spec config file",
+		},
+		cli.StringFlag{
+			Name:  "runtime-file, r",
+			Value: "runtime.json",
+			Usage: "path to runtime config file",
+		},
+	},
+	Action: func(context *cli.Context) {
+		config, err := loadStartConfig(context)
+		if err != nil {
+			fmt.Errorf("load config failed %v\n", err)
+			os.Exit(-1)
+		}
+		if os.Geteuid() != 0 {
+			fmt.Errorf("runv should be run as root\n")
+			os.Exit(-1)
+		}
+
+		startVContainer(config)
+	},
+}


### PR DESCRIPTION


The runv supports pod-style shared namespaces currently.
(More fine grain shared namespaces style (docker/runc style) is under implementation)

Pod-style shared namespaces:
 * if two containers share at least one type of namespace, they share all kinds of namespaces except the mount namespace
 * mount namespace can't be shared, each container has its own mount namespace

 Implementation detail:
 * Shared namespaces is configured in LinuxRuntimeSpec.Linux.Namespaces, the namespace Path should be existing container name.
 * In runv, shared namespaces multiple containers are located in the same VM which is managed by a runv-daemon.
 * Any running container can exit in any arbitrary order, the runv-daemon and the VM are existed until the last container of the VM is existed
