### PR TITLE
fix panic when execcmd

### DIFF
--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -465,7 +465,7 @@ func (vm *Vm) KillContainer(container string, signal syscall.Signal) error {
 		}
 
 		glog.V(1).Infof("Got response: %d: %s", Response.Code, Response.Cause)
-		if Response.Reply.(*KillCommand) == killCmd {
+		if Response.Reply == killCmd {
 			if Response.Cause != "" {
 				return fmt.Errorf("kill container %v failed: %s", container, Response.Cause)
 			}
@@ -522,7 +522,7 @@ func (vm *Vm) Exec(Stdin io.ReadCloser, Stdout io.WriteCloser, cmd, tag, contain
 		}
 
 		glog.V(1).Infof("Got response: %d: %s", Response.Code, Response.Cause)
-		if Response.Reply.(*ExecCommand) == execCmd {
+		if Response.Reply == execCmd {
 			if Response.Cause != "" {
 				return fmt.Errorf("exec command %v failed: %s", command, Response.Cause)
 			}


### PR DESCRIPTION
2015/12/09 15:55:45 http: panic serving @: interface conversion: interface {} is *hypervisor.GetPodIPCommand, not *hypervisor.ExecCommand
goroutine 297 [running]:
net/http.(*conn).serve.func1(0xc820c70fd0, 0x7fbd941a4d70, 0xc820ca7108)
	/usr/lib/golang/src/net/http/server.go:1287 +0xb5
github.com/hyperhq/runv/hypervisor.(*Vm).Exec(0xc820015220, 0x0, 0x0, 0x0, 0x0, 0xc820ba8a80, 0x72, 0x0, 0x0, 0xc820516540, ...)
	/home/gaofeng/go/src/github.com/hyperhq/runv/hypervisor/vm.go:525 +0xa71
github.com/hyperhq/hyper/servicediscovery.ApplyServices(0xc820015220, 0xc820516540, 0x40, 0xc820c38400, 0x1, 0x4, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/hyperhq/hyper/servicediscovery/servicediscovery.go:106 +0x539
github.com/hyperhq/hyper/daemon.(*Daemon).UpdateService(0xc82015a000, 0xc820532b40, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/hyperhq/hyper/daemon/servicediscovery.go:60 +0x232
github.com/hyperhq/hyper/daemon.(*Daemon).UpdateService-fm(0xc820532b40, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/hyperhq/hyper/daemon/daemon.go:96 +0x38
github.com/hyperhq/hyper/engine.(*Job).Run(0xc820532b40, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/hyperhq/hyper/engine/job.go:95 +0x6b2
github.com/hyperhq/hyper/server.postServiceUpdate(0xc82021e0c0, 0xcb7dd0, 0x4, 0x7fbd941a4ef0, 0xc820c71080, 0xc82041c620, 0xc820418f60, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/hyperhq/hyper/server/server.go:967 +0x2d2
github.com/hyperhq/hyper/server.makeHttpHandler.func1(0x7fbd941a4ef0, 0xc820c71080, 0xc82041c620)
	/home/gaofeng/go/src/github.com/hyperhq/hyper/server/server.go:1039 +0xa84
net/http.HandlerFunc.ServeHTTP(0xc8203dc8a0, 0x7fbd941a4ef0, 0xc820c71080, 0xc82041c620)
	/usr/lib/golang/src/net/http/server.go:1422 +0x3a
github.com/gorilla/mux.(*Router).ServeHTTP(0xc8200563c0, 0x7fbd941a4ef0, 0xc820c71080, 0xc82041c620)
	/home/gaofeng/go/src/github.com/hyperhq/hyper/Godeps/_workspace/src/github.com/gorilla/mux/mux.go:100 +0x29e
net/http.serverHandler.ServeHTTP(0xc8203dd3e0, 0x7fbd941a4ef0, 0xc820c71080, 0xc82041c620)
	/usr/lib/golang/src/net/http/server.go:1862 +0x19e
net/http.(*conn).serve(0xc820c70fd0)
	/usr/lib/golang/src/net/http/server.go:1361 +0xbee
created by net/http.(*Server).Serve
	/usr/lib/golang/src/net/http/server.go:1910 +0x3f6

Signed-off-by: Gao feng <omarapazanadi@gmail.com>