### PR TITLE
(do NOT merge) Enable lazy launch for qemu driver

### DIFF
--- a/hypervisor/driver.go
+++ b/hypervisor/driver.go
@@ -42,6 +42,9 @@ type HypervisorDriver interface {
 	InitNetwork(bIface, bIP string) error
 
 	SupportLazyMode() bool
+
+	AsyncDiskBoot() bool
+	AsyncNicBoot() bool
 }
 
 var HDriver HypervisorDriver
@@ -64,16 +67,12 @@ type DriverContext interface {
 	AllocateNetwork(vmId, requestedIP string, maps []pod.UserContainerPort) (*network.Settings, error)
 	ReleaseNetwork(vmId, releasedIP string, maps []pod.UserContainerPort, file *os.File) error
 
-	Close()
-}
-
-type LazyDriverContext interface {
-	DriverContext
-
 	LazyLaunch(ctx *VmContext)
 	InitVM(ctx *VmContext) error
 	LazyAddDisk(ctx *VmContext, name, sourceType, filename, format string, id int)
 	LazyAddNic(ctx *VmContext, host *HostNicInfo, guest *GuestNicInfo)
+
+	Close()
 }
 
 type EmptyDriver struct{}
@@ -97,6 +96,14 @@ func (ed *EmptyDriver) LoadContext(persisted map[string]interface{}) (DriverCont
 
 func (ed *EmptyDriver) SupportLazyMode() bool {
 	return false
+}
+
+func (ed *EmptyDriver) AsyncDiskBoot() bool {
+	return true
+}
+
+func (ed *EmptyDriver) AsyncNicBoot() bool {
+	return true
 }
 
 func (ec *EmptyContext) Launch(ctx *VmContext) {}
@@ -136,5 +143,14 @@ func (ec *EmptyContext) ReleaseNetwork(vmId, releasedIP string,
 	maps []pod.UserContainerPort, file *os.File) error {
 	return nil
 }
+
+func (ec *EmptyContext) LazyLaunch(ctx *VmContext) {}
+
+func (ec *EmptyContext) InitVM(ctx *VmContext) error { return nil }
+
+func (ec *EmptyContext) LazyAddDisk(ctx *VmContext, name, sourceType, filename, format string, id int) {
+}
+
+func (ec *EmptyContext) LazyAddNic(ctx *VmContext, host *HostNicInfo, guest *GuestNicInfo) {}
 
 func (ec *EmptyContext) Close() {}

--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -408,8 +408,16 @@ func (vc *VBoxContext) detachDisk(disk string, port int) error {
 	return nil
 }
 
-func (vc *VBoxDriver) SupportLazyMode() bool {
+func (vd *VBoxDriver) SupportLazyMode() bool {
 	return true
+}
+
+func (vd *VBoxDriver) AsyncDiskBoot() bool {
+	return false
+}
+
+func (vd *VBoxDriver) AsyncNicBoot() bool {
+	return false
 }
 
 func scsiId2Name(id int) string {

--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -54,10 +54,10 @@ func (vm *Vm) Launch(b *BootConfig) (err error) {
 		Status   = make(chan *types.VmResponse, 128)
 	)
 
-	if vm.Lazy {
-		go LazyVmLoop(vm.Id, PodEvent, Status, b, vm.Keep)
-	} else {
+	if HDriver.AsyncDiskBoot() && HDriver.AsyncNicBoot() {
 		go VmLoop(vm.Id, PodEvent, Status, b, vm.Keep)
+	} else {
+		go LazyVmLoop(vm.Id, PodEvent, Status, b, vm.Keep)
 	}
 
 	vm.VmChan = PodEvent

--- a/hypervisor/xen/xen.go
+++ b/hypervisor/xen/xen.go
@@ -276,6 +276,24 @@ func (xd *XenDriver) SupportLazyMode() bool {
 	return false
 }
 
+func (xd *XenDriver) AsyncDiskBoot() bool {
+	return true
+}
+
+func (xd *XenDriver) AsyncNicBoot() bool {
+	return true
+}
+
+func (xc *XenContext) LazyLaunch(ctx *hypervisor.VmContext) {}
+
+func (xc *XenContext) InitVM(ctx *hypervisor.VmContext) error { return nil }
+
+func (xc *XenContext) LazyAddDisk(ctx *hypervisor.VmContext, name, sourceType, filename, format string, id int) {
+}
+
+func (xc *XenContext) LazyAddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo) {
+}
+
 func diskRoutine(add bool, xc *XenContext, ctx *hypervisor.VmContext,
 	name, sourceType, filename, format string, id int, callback hypervisor.VmEvent) {
 	backend := LIBXL_DISK_BACKEND_TAP

--- a/hypervisor/xen/xen_unsupported.go
+++ b/hypervisor/xen/xen_unsupported.go
@@ -36,3 +36,11 @@ func (xd *XenDriver) LoadContext(persisted map[string]interface{}) (hypervisor.D
 func (xd *XenDriver) SupportLazyMode() bool {
 	return false
 }
+
+func (xd *XenDriver) AsyncDiskBoot() bool {
+	return true
+}
+
+func (xd *XenDriver) AsyncNicBoot() bool {
+	return true
+}


### PR DESCRIPTION
Current persistent memory is not support hotplug,
so we add the lazy launch functionality to the qemu driver
and perpare for adding dax functionality (via persistent memory)
in future.
(the lazy launch functionality = the vm is not launched until startpod)

All lazy functions are moved to the DriverContext interface,
and the LazyDriverContext is removed.

The interface HypervisorDriver adds AsyncDiskBoot() and AsyncNicBoot(),
and when either one of it returns false, the driver should use
the lazy launch functionality to lunch the vm.

When persistent memory is supported, the qemu driver only brings disks
to qemu argument when boot. The Nics are still async boot.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>