### PR TITLE
add libvirt check in autoconf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,7 @@ matrix:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y autoconf libdevmapper-dev libvirt-dev -qq
-  - cd `mktemp -d`
-  - wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz
-  - tar xJf autoconf-2.69.tar.xz
-  - cd autoconf-2.69
-  - ./configure && make && sudo make install
-  - wget http://ftp.gnu.org/gnu/automake/automake-1.15.tar.xz
-  - tar xJf automake-1.15.tar.xz
-  - cd automake-1.15
-  - ./configure && make && sudo make install
+  - sudo apt-get install -y autoconf automake pkg-config libdevmapper-dev libvirt-dev -qq
 
 script: 
   - cd ${TRAVIS_BUILD_DIR}

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,17 @@
 export GOPATH:=$(abs_top_srcdir)/Godeps/_workspace:$(GOPATH)
 if WITH_XEN
-HYPER_BULD_TAGS=with_xen
+XEN_BUILD_TAG=with_xen
 else
-HYPER_BULD_TAGS=
+XEN_BUILD_TAG=
 endif
 
+if WITH_LIBVIRT
+LIBVIRT_BUILD_TAG=with_libvirt
+else
+LIBVIRT_BUILD_TAG=
+endif
+
+HYPER_BULD_TAGS=$(XEN_BUILD_TAG) $(LIBVIRT_BUILD_TAG)
 all-local: build-runv
 clean-local:
 	-rm -f runv

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,19 @@ esac
 
 # Checks for libraries.
 
+LIBVIRT_REQUIRED="1.2.2"
+
+AC_ARG_WITH([libvirt],
+            [AS_HELP_STRING([--without-libvirt],
+                            [run runv with libvirt])],
+            [with_libvirt=no],[with_libvirt=yes])
+
+if test "$with_libvirt" = yes; then
+	PKG_CHECK_MODULES([LIBVIRT], [libvirt >= $LIBVIRT_REQUIRED], [], [with_libvirt=no])
+fi
+
+AM_CONDITIONAL([WITH_LIBVIRT], [test "x$with_libvirt" == "xyes"])
+
 # Checks for header files.
 AC_CHECK_HEADERS([stdlib.h string.h libxl.h])
 
@@ -70,7 +83,7 @@ AC_CHECK_FUNCS([strdup])
 
 AC_ARG_WITH([xen],
             [AS_HELP_STRING([--without-xen],
-                            [run hyperd with xen (libxl, need xen 4.5 or higher)])],
+                            [run runv with xen (libxl, need xen 4.5 or higher)])],
             [with_xen=no],[with_xen=yes])
 
 if test "x$with_xen" != "xno" ; then
@@ -99,6 +112,8 @@ AC_MSG_RESULT([
 	has go:     ${has_go}
 
 	with xen:   ${with_xen}
+
+	with libvirt: ${with_libvirt}
 
 	has virtualbox: ${has_virtualbox}
 ])

--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -1,3 +1,5 @@
+// +build linux,with_libvirt
+
 package libvirt
 
 import (

--- a/hypervisor/libvirt/libvirt_unsupported.go
+++ b/hypervisor/libvirt/libvirt_unsupported.go
@@ -1,0 +1,36 @@
+// +build !with_libvirt
+
+package libvirt
+
+import (
+	"errors"
+	"github.com/hyperhq/runv/hypervisor"
+)
+
+type LibvirtDriver struct{}
+
+type LibvirtContext struct {
+	driver *LibvirtDriver
+}
+
+func InitDriver() *LibvirtDriver {
+	return nil
+}
+
+var unsupportErr error = errors.New("Did not built with libvirt support")
+
+func (ld *LibvirtDriver) Initialize() error {
+	return unsupportErr
+}
+
+func (ld *LibvirtDriver) InitContext(homeDir string) hypervisor.DriverContext {
+	return nil
+}
+
+func (ld *LibvirtDriver) LoadContext(persisted map[string]interface{}) (hypervisor.DriverContext, error) {
+	return nil, unsupportErr
+}
+
+func (ld *LibvirtDriver) SupportLazyMode() bool {
+	return false
+}


### PR DESCRIPTION
Runv try to enable libvirt by default. if there is no libvirt-dev package
or the version is low than 1.2.2, user should update/install libvirt-dev or
reconfigure runv with --without-libvirt.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>