### PR TITLE
shutdown libvirt vm with destroy

### DIFF
--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -449,7 +449,7 @@ func (lc *LibvirtContext) Shutdown(ctx *hypervisor.VmContext) {
 		if err != nil {
 			return
 		}
-		lc.domain.ShutdownFlags(libvirtgo.VIR_DOMAIN_SHUTDOWN_DEFAULT)
+		lc.domain.DestroyFlags(libvirtgo.VIR_DOMAIN_DESTROY_DEFAULT)
 		delete(lc.driver.domains, name)
 		ctx.Hub <- &hypervisor.VmExit{}
 	}()


### PR DESCRIPTION
shutdownflags doesn't shutdown vm actually, use destroyflags
to make sure shutdown vm successfully.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>