### PR TITLE
Fix volume filename

### DIFF
--- a/hypervisor/devicemap.go
+++ b/hypervisor/devicemap.go
@@ -230,7 +230,10 @@ func (ctx *VmContext) setVolumeInfo(info *VolumeInfo) {
 		return
 	}
 
-	vol.info.filename = info.Filepath
+	if len(vol.info.filename) == 0 {
+		vol.info.filename = info.Filepath
+	}
+
 	vol.info.format = info.Format
 
 	if info.Fstype != "dir" {


### PR DESCRIPTION
`setVolumeInfo` should not override volume name setted up at `initVolumeMap`

Fix #108