### PR TITLE
decide to colse the fanout chan or not by the event handler

### DIFF
--- a/hypervisor/pod.go
+++ b/hypervisor/pod.go
@@ -14,7 +14,7 @@ import (
 //  gsed -ie 's/^    \([a-z]\)\([a-zA-Z]*\)\( \{1,\}[^ ]\{1,\}.*\)$/    \U\1\E\2\3 `json:"\1\2"`/' pod.go
 
 type HandleEvent struct {
-	Handle func(*types.VmResponse, interface{}, *PodStatus, *Vm) bool
+	Handle func(*types.VmResponse, interface{}, *PodStatus, *Vm) (bool, bool)
 	Data   interface{}
 }
 

--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -180,7 +180,7 @@ func (vm *Vm) ReleaseVm() (int, error) {
 }
 
 func defaultHandlePodEvent(Response *types.VmResponse, data interface{},
-	mypod *PodStatus, vm *Vm) bool {
+	mypod *PodStatus, vm *Vm) (bool, bool) {
 	if Response.Code == types.E_POD_FINISHED {
 		mypod.SetPodContainerStatus(Response.Data.([]uint32))
 		mypod.Vm = ""
@@ -191,10 +191,10 @@ func defaultHandlePodEvent(Response *types.VmResponse, data interface{},
 			mypod.SetContainerStatus(types.S_POD_SUCCEEDED)
 		}
 		mypod.Vm = ""
-		return true
+		return true, true
 	}
 
-	return false
+	return false, false
 }
 
 func (vm *Vm) handlePodEvent(mypod *PodStatus) {
@@ -212,10 +212,12 @@ func (vm *Vm) handlePodEvent(mypod *PodStatus) {
 			break
 		}
 
-		exit := mypod.Handler.Handle(Response, mypod.Handler.Data, mypod, vm)
+		exit, close := mypod.Handler.Handle(Response, mypod.Handler.Data, mypod, vm)
 		if exit {
-			vm.clients.Close()
-			vm.clients = nil
+			if close {
+				vm.clients.Close()
+				vm.clients = nil
+			}
 			break
 		}
 	}


### PR DESCRIPTION
in replace, the old pod is stopped, but the event handler is still
running and operating the vm, after new pod start, there will be two
event handlers to operate the same vm, this may cause panic on close
vm's fanout chan twice. and will cause two handler to operate the same
podstatus when we start the old pod again. such as

hyper start pod-a
hyper replace -o pod-a -n pod-b
hyper start pod-a
hyper stop pod-b

you will see the status of pod-a is failed too. but the hypervisor is still
running.

fix this problem by finishing the event handler of old pod when receiving
the pod stopped event(in hyper) and don't close the fanout chan is this
case(vm is still running). this will make sure only one handler is using
the vm.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>