### PR TITLE
fix erros from "go tool vet ."

### DIFF
--- a/hypervisor/network/network_test.go
+++ b/hypervisor/network/network_test.go
@@ -24,7 +24,7 @@ func TestAllocate(t *testing.T) {
 	if setting, err := Allocate("192.168.138.2"); err != nil {
 		t.Error("allocate tap device and ip failed")
 	} else {
-		t.Log("alocate tap device finished. bridge %s, device %s, ip %s, gateway %s",
+		t.Logf("alocate tap device finished. bridge %s, device %s, ip %s, gateway %s",
 			setting.Bridge, setting.Device, setting.IPAddress, setting.Gateway)
 
 		if err := Release("192.168.138.2", setting.File); err != nil {

--- a/hypervisor/pod/pod.go
+++ b/hypervisor/pod/pod.go
@@ -266,7 +266,7 @@ func (pod *UserPod) Validate() error {
 			}
 			if f.Perm != "0" {
 				if !permReg.Match([]byte(f.Perm)) {
-					return fmt.Errorf("in container %d, the permission %s only accept Octal digital in string")
+					return fmt.Errorf("in container %d, the permission %s only accept Octal digital in string", idx, f.Perm)
 				}
 			}
 		}

--- a/hypervisor/qemu/qemu_process.go
+++ b/hypervisor/qemu/qemu_process.go
@@ -66,7 +66,7 @@ func launchQemu(qc *QemuContext, ctx *hypervisor.VmContext) {
 	pid, err := utils.ExecInDaemon(qemu, append([]string{"qemu-system-x86_64"}, args...))
 	if err != nil {
 		//fail to daemonize
-		glog.Error("%v", err)
+		glog.Errorf("%v", err)
 		ctx.Hub <- &hypervisor.VmStartFailEvent{Message: "try to start qemu failed"}
 		return
 	}

--- a/hypervisor/qemu/qmp_test.go
+++ b/hypervisor/qemu/qmp_test.go
@@ -38,7 +38,7 @@ func TestMessageParse(t *testing.T) {
 func testQmpInitHelper(t *testing.T, ctx *QemuContext) (*net.UnixListener, net.Conn) {
 	t.Log("setup ", ctx.qmpSockName)
 
-	ss, err := net.ListenUnix("unix", &net.UnixAddr{ctx.qmpSockName, "unix"})
+	ss, err := net.ListenUnix("unix", &net.UnixAddr{Name: ctx.qmpSockName, Net: "unix"})
 	if err != nil {
 		t.Error("fail to setup connect to qmp socket", err.Error())
 	}
@@ -127,7 +127,7 @@ func TestInitFail(t *testing.T) {
 
 	t.Log("setup ", qc.qmpSockName)
 
-	ss, err := net.ListenUnix("unix", &net.UnixAddr{qc.qmpSockName, "unix"})
+	ss, err := net.ListenUnix("unix", &net.UnixAddr{Name: qc.qmpSockName, Net: "unix"})
 	if err != nil {
 		t.Error("fail to setup connect to qmp socket", err.Error())
 	}
@@ -202,7 +202,7 @@ func TestQmpInitTimeout(t *testing.T) {
 
 	t.Log("connecting to ", qc.qmpSockName)
 
-	ss, err := net.ListenUnix("unix", &net.UnixAddr{qc.qmpSockName, "unix"})
+	ss, err := net.ListenUnix("unix", &net.UnixAddr{Name: qc.qmpSockName, Net: "unix"})
 	if err != nil {
 		t.Error("fail to setup connect to qmp socket", err.Error())
 	}

--- a/lib/telnet/conn.go
+++ b/lib/telnet/conn.go
@@ -327,7 +327,6 @@ func (c *Conn) readUntil(read bool, delims ...string) ([]byte, int, error) {
 			}
 		}
 	}
-	panic(nil)
 }
 
 // ReadUntilIndex reads from connection until one of delimiters occurs. Returns


### PR DESCRIPTION
hypervisor/network/network_test.go:27: possible formatting directive in
Log call
hypervisor/pod/pod.go:269: missing argument for Errorf("%d"): format
reads arg 1, have only 0 args
hypervisor/qemu/qemu_process.go:69: possible formatting directive in
Error call
hypervisor/qemu/qmp_test.go:41: net.UnixAddr composite literal uses
unkeyed fields
hypervisor/qemu/qmp_test.go:130: net.UnixAddr composite literal uses
unkeyed fields
hypervisor/qemu/qmp_test.go:205: net.UnixAddr composite literal uses
unkeyed fields
lib/telnet/conn.go:330: unreachable code

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>