### PR TITLE
don't recevice stdin if container/exec haven't started

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -52,6 +52,8 @@ type VmContext struct {
 	ptys        *pseudoTtys
 	ttySessions map[string]uint64
 	pendingTtys []*AttachCommand
+	pendingNum  int
+	startedChan chan bool
 
 	// Specification
 	userSpec *pod.UserPod
@@ -113,6 +115,8 @@ func InitContext(id string, hub chan VmEvent, client chan *types.VmResponse, dc 
 		ptys:            newPts(),
 		ttySessions:     make(map[string]uint64),
 		pendingTtys:     []*AttachCommand{},
+		pendingNum:      0,
+		startedChan:     make(chan bool),
 		HomeDir:         homeDir,
 		HyperSockName:   hyperSockName,
 		TtySockName:     ttySockName,
@@ -224,6 +228,7 @@ func (ctx *VmContext) ClosePendingTtys() {
 		tty.Streams.Close(255)
 	}
 	ctx.pendingTtys = []*AttachCommand{}
+	close(ctx.startedChan)
 }
 
 func (ctx *VmContext) Close() {

--- a/hypervisor/events.go
+++ b/hypervisor/events.go
@@ -64,15 +64,18 @@ type PauseResult struct {
 }
 
 type NewContainerCommand struct {
-	container *pod.UserContainer
-	info      *ContainerInfo
+	container   *pod.UserContainer
+	info        *ContainerInfo
+	pendingNum  int
+	startedChan chan bool
 }
 
 type ExecCommand struct {
-	*TtyIO    `json:"-"`
-	Sequence  uint64   `json:"seq"`
-	Container string   `json:"container,omitempty"`
-	Command   []string `json:"cmd"`
+	*TtyIO      `json:"-"`
+	StartedChan chan bool `json:"-"`
+	Sequence    uint64    `json:"seq"`
+	Container   string    `json:"container,omitempty"`
+	Command     []string  `json:"cmd"`
 }
 
 type KillCommand struct {

--- a/lib/term/tty.go
+++ b/lib/term/tty.go
@@ -26,8 +26,7 @@ func TtySplice(conn net.Conn) (int, error) {
 
 	sendStdin := make(chan error, 1)
 	go func() {
-		written, err := io.Copy(conn, os.Stdin)
-		fmt.Printf("copy from stdin to remote %v, err %v\n", written, err)
+		_, _ = io.Copy(conn, os.Stdin)
 
 		if sock, ok := conn.(interface {
 			CloseWrite() error


### PR DESCRIPTION
Since the container/exec may haven't started yet, if hyperstart
received the unknown session' tty data, it will send eof message
to notify hyperd to close the connection.

You can reproduce this problem by press enter button all the time
after execute `hyper run -t image cmd`

Fix this problem by don't receive stdio input data before hyperd
get the ack of startpod/newcontainer/exec.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>