### PR TITLE
Ptys refactor part2

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -257,11 +257,9 @@ func (ctx *VmContext) InitDeviceContext(spec *pod.UserPod, wg *sync.WaitGroup,
 		containers[i].Sysctl = container.Sysctl
 		containers[i].Tty = ctx.ptys.attachId
 		ctx.ptys.attachId++
-		ctx.ptys.ttys[containers[i].Tty] = newAttachments(i, true)
 		if !spec.Tty {
 			containers[i].Stderr = ctx.ptys.attachId
 			ctx.ptys.attachId++
-			ctx.ptys.ttys[containers[i].Stderr] = newAttachments(i, true)
 		}
 	}
 

--- a/hypervisor/persistence.go
+++ b/hypervisor/persistence.go
@@ -183,13 +183,6 @@ func (pinfo *PersistInfo) vmContext(hub chan VmEvent, client chan *types.VmRespo
 
 	ctx.loadHwStatus(pinfo)
 
-	for idx, container := range ctx.vmSpec.Containers {
-		ctx.ptys.ttys[container.Tty] = newAttachments(idx, true)
-		if container.Stderr > 0 {
-			ctx.ptys.ttys[container.Stderr] = newAttachments(idx, true)
-		}
-	}
-
 	for _, vol := range pinfo.VolumeList {
 		binfo := vol.blockInfo()
 		if len(vol.Containers) != len(vol.MontPoints) {

--- a/hypervisor/tty.go
+++ b/hypervisor/tty.go
@@ -189,13 +189,6 @@ func waitPts(ctx *VmContext) {
 	}
 }
 
-func newAttachments(idx int, persist bool) *ttyAttachments {
-	return &ttyAttachments{
-		persistent:  persist,
-		attachments: []*TtyIO{},
-	}
-}
-
 func newAttachmentsWithTty(idx int, persist bool, tty *TtyIO) *ttyAttachments {
 	return &ttyAttachments{
 		persistent:  persist,
@@ -304,13 +297,13 @@ func (pts *pseudoTtys) Close(ctx *VmContext, session uint64, code uint8) {
 	}
 }
 
-func (pts *pseudoTtys) ptyConnect(ctx *VmContext, container int, session uint64, tty *TtyIO) {
+func (pts *pseudoTtys) ptyConnect(ctx *VmContext, container int, persist bool, session uint64, tty *TtyIO) {
 
 	pts.lock.Lock()
 	if ta, ok := pts.ttys[session]; ok {
 		ta.attach(tty)
 	} else {
-		pts.ttys[session] = newAttachmentsWithTty(container, false, tty)
+		pts.ttys[session] = newAttachmentsWithTty(container, persist, tty)
 	}
 	pts.lock.Unlock()
 

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -310,7 +310,6 @@ func (ctx *VmContext) attachTty2Container(idx int, cmd *AttachCommand) {
 				Stdout:    cmd.Streams.Stdout,
 				ClientTag: cmd.Streams.ClientTag,
 				Callback:  nil,
-				liner:     &linerTransformer{},
 			}
 		}
 		ctx.ptys.ptyConnect(ctx, idx, session, stderrIO)


### PR DESCRIPTION
remove the wrong linerTransformer

the second path simplifies Attachments allocation, all are allocated
in ptyConnect(), and it  doesn't change any functionality.