### PR TITLE
change VmContainer's stdio's protocal and send tty into hyperstart

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -255,7 +255,8 @@ func (ctx *VmContext) InitDeviceContext(spec *pod.UserPod, wg *sync.WaitGroup,
 		ctx.setContainerInfo(i, &containers[i], cInfo[i])
 
 		containers[i].Sysctl = container.Sysctl
-		containers[i].Tty = ctx.ptys.attachId
+		containers[i].Tty = spec.Tty
+		containers[i].Stdio = ctx.ptys.attachId
 		ctx.ptys.attachId++
 		if !spec.Tty {
 			containers[i].Stderr = ctx.ptys.attachId

--- a/hypervisor/devicemap.go
+++ b/hypervisor/devicemap.go
@@ -116,7 +116,7 @@ func (ctx *VmContext) initContainerInfo(index int, target *VmContainer, spec *po
 
 	*target = VmContainer{
 		Id: "", Rootfs: "rootfs", Fstype: "", Image: "",
-		Volumes: vols, Fsmap: fsmap, Tty: 0, Stderr: 0,
+		Volumes: vols, Fsmap: fsmap, Tty: spec.Tty, Stdio: 0, Stderr: 0,
 		Workdir: spec.Workdir, Entrypoint: spec.Entrypoint, Cmd: spec.Command, Envs: envs,
 		RestartPolicy: restart,
 	}

--- a/hypervisor/pod.go
+++ b/hypervisor/pod.go
@@ -80,7 +80,8 @@ type VmContainer struct {
 	Volumes       []VmVolumeDescriptor `json:"volumes,omitempty"`
 	Fsmap         []VmFsmapDescriptor  `json:"fsmap,omitempty"`
 	Sysctl        map[string]string    `json:"sysctl,omitempty"`
-	Tty           uint64               `json:"tty,omitempty"`
+	Tty           bool                 `json:"tty"`
+	Stdio         uint64               `json:"stdio,omitempty"`
 	Stderr        uint64               `json:"stderr,omitempty"`
 	Workdir       string               `json:"workdir"`
 	Entrypoint    []string             `json:"-"`

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -87,7 +87,8 @@ func (ctx *VmContext) prepareContainer(cmd *NewContainerCommand) *VmContainer {
 	ctx.setContainerInfo(idx, vmContainer, cmd.info)
 
 	vmContainer.Sysctl = cmd.container.Sysctl
-	vmContainer.Tty = ctx.ptys.attachId
+	vmContainer.Tty = cmd.container.Tty
+	vmContainer.Stdio = ctx.ptys.attachId
 	ctx.ptys.attachId++
 	if !cmd.container.Tty {
 		vmContainer.Stderr = ctx.ptys.attachId
@@ -275,7 +276,7 @@ func (ctx *VmContext) attachCmd(cmd *AttachCommand) {
 		ctx.ptys.pendingTtys = append(ctx.ptys.pendingTtys, cmd)
 		glog.V(1).Infof("attachment %s is pending", cmd.Streams.ClientTag)
 		return
-	} else if idx < 0 || idx > len(ctx.vmSpec.Containers) || ctx.vmSpec.Containers[idx].Tty == 0 {
+	} else if idx < 0 || idx > len(ctx.vmSpec.Containers) || ctx.vmSpec.Containers[idx].Stdio == 0 {
 		cause := fmt.Sprintf("tty is not configured for %s", cmd.Container)
 		ctx.reportBadRequest(cause)
 		cmd.Streams.Callback <- &types.VmResponse{
@@ -293,7 +294,7 @@ func (ctx *VmContext) attachCmd(cmd *AttachCommand) {
 }
 
 func (ctx *VmContext) attachTty2Container(idx int, cmd *AttachCommand) {
-	session := ctx.vmSpec.Containers[idx].Tty
+	session := ctx.vmSpec.Containers[idx].Stdio
 	ctx.ptys.ptyConnect(true, session, cmd.Streams)
 	ctx.ptys.clientReg(cmd.Streams.ClientTag, session)
 	glog.V(1).Infof("Connecting tty for %s on session %d", cmd.Container, session)


### PR DESCRIPTION
VmContainer.Tty: allocate tty or not
VmContainer.Stdio: Stdio sequence number
VmContainer.Stderr: Stderr sequence number if stderr is not share with
stdout (currently used when VmContainer.Tty is false)

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>