### PR TITLE
use per-container tty conf in pod spec

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -255,10 +255,9 @@ func (ctx *VmContext) InitDeviceContext(spec *pod.UserPod, wg *sync.WaitGroup,
 		ctx.setContainerInfo(i, &containers[i], cInfo[i])
 
 		containers[i].Sysctl = container.Sysctl
-		containers[i].Tty = spec.Tty
 		containers[i].Stdio = ctx.ptys.attachId
 		ctx.ptys.attachId++
-		if !spec.Tty {
+		if !container.Tty {
 			containers[i].Stderr = ctx.ptys.attachId
 			ctx.ptys.attachId++
 		}

--- a/hypervisor/pod/pod.go
+++ b/hypervisor/pod/pod.go
@@ -156,14 +156,14 @@ func ProcessPodBytes(body []byte) (*UserPod, error) {
 	}
 
 	var (
-		v   UserContainer
 		vol UserVolume
 		num = 0
 	)
-	for _, v = range userPod.Containers {
+	for i, v := range userPod.Containers {
 		if v.Image == "" {
 			return nil, fmt.Errorf("Please specific your image for your container, it can not be null!\n")
 		}
+		userPod.Containers[i].Tty = v.Tty || userPod.Tty
 		num++
 	}
 	if num == 0 {


### PR DESCRIPTION
- global tty conf in pod spec is now deprecated
- currently container tty option will be (pod.tty || container.tty)

Signed-off-by: Xu Wang <gnawux@gmail.com>