### PR TITLE
Support flying vm without hyperd manage

### DIFF
--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -100,6 +100,10 @@ func VmAssociate(vmId string, hub chan VmEvent, client chan *types.VmResponse,
 
 	context.Become(stateRunning, "RUNNING")
 
+	for _, c := range context.vmSpec.Containers {
+		context.ptys.startStdin(c.Stdio, c.Tty)
+	}
+
 	context.loop()
 }
 

--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -442,7 +442,7 @@ func (lc *LibvirtContext) Launch(ctx *hypervisor.VmContext) {
 	}
 	glog.V(3).Infof("domainXML: %v", domainXml)
 
-	domain, err := lc.driver.conn.DomainCreateXML(domainXml, libvirtgo.VIR_DOMAIN_START_AUTODESTROY)
+	domain, err := lc.driver.conn.DomainCreateXML(domainXml, libvirtgo.VIR_DOMAIN_NONE)
 	if err != nil {
 		glog.Error("Fail to launch domain ", err)
 		ctx.Hub <- &hypervisor.VmStartFailEvent{Message: err.Error()}

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -561,7 +561,8 @@ func stateInit(ctx *VmContext, ev VmEvent) {
 
 				// start stdin. TODO: find the correct idx if parallel multi INIT_NEWCONTAINER
 				idx := len(ctx.vmSpec.Containers) - 1
-				ctx.ptys.startStdin(ctx.vmSpec.Containers[idx].Stdio)
+				c := ctx.vmSpec.Containers[idx]
+				ctx.ptys.startStdin(c.Stdio, c.Tty)
 			}
 		default:
 			unexpectedEventHandler(ctx, ev, "pod initiating")
@@ -612,7 +613,7 @@ func stateStarting(ctx *VmContext, ev VmEvent) {
 					}
 				}
 				for _, c := range ctx.vmSpec.Containers {
-					ctx.ptys.startStdin(c.Stdio)
+					ctx.ptys.startStdin(c.Stdio, c.Tty)
 				}
 				ctx.reportSuccess("Start POD success", pinfo)
 				ctx.Become(stateRunning, "RUNNING")
@@ -682,7 +683,7 @@ func stateRunning(ctx *VmContext, ev VmEvent) {
 
 			if ack.reply.Code == INIT_EXECCMD {
 				cmd := ack.reply.Event.(*ExecCommand)
-				ctx.ptys.startStdin(cmd.Sequence)
+				ctx.ptys.startStdin(cmd.Sequence, true)
 				ctx.reportExec(ack.reply.Event, false)
 				glog.Infof("Get ack for exec cmd")
 			} else if ack.reply.Code == INIT_READFILE {
@@ -695,7 +696,8 @@ func stateRunning(ctx *VmContext, ev VmEvent) {
 				glog.Infof("Get ack for new container")
 				// start stdin. TODO: find the correct idx if parallel multi INIT_NEWCONTAINER
 				idx := len(ctx.vmSpec.Containers) - 1
-				ctx.ptys.startStdin(ctx.vmSpec.Containers[idx].Stdio)
+				c := ctx.vmSpec.Containers[idx]
+				ctx.ptys.startStdin(c.Stdio, c.Tty)
 			}
 		case ERROR_CMD_FAIL:
 			ack := ev.(*CommandError)


### PR DESCRIPTION
To support flying vm, hyper will create libvirt domain without AUTODESTROY flag to make sure domain alive when hyperd exited. 
And setup started flag for tty attachment of container to allow client to input data.