### PR TITLE
container: store mountid to container info

### DIFF
--- a/hypervisor/events.go
+++ b/hypervisor/events.go
@@ -132,9 +132,10 @@ type ContainerCreatedEvent struct {
 }
 
 type ContainerInfo struct {
-	Id     string
-	Rootfs string
-	Image  string // if fstype is `dir`, this should be a path relative to share_dir
+	Id      string
+	MountId string
+	Rootfs  string
+	Image   string // if fstype is `dir`, this should be a path relative to share_dir
 	// which described the mounted aufs or overlayfs dir.
 	Fstype     string
 	Workdir    string


### PR DESCRIPTION
inspect container is removed in start, so store mountid to
make sure get the correct mountid.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>