### PR TITLE
revert 208e30f3 and add balloon back

### DIFF
--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -203,7 +203,8 @@ type console struct {
 }
 
 type memballoon struct {
-	Model string `xml:"model,attr"`
+	Model   string   `xml:"model,attr"`
+	Address *address `xml:"address"`
 }
 
 type device struct {
@@ -400,8 +401,16 @@ func (lc *LibvirtContext) domainXml(ctx *hypervisor.VmContext) (string, error) {
 			Port: "0",
 		},
 	}
+
 	dom.Devices.Memballoon = memballoon{
-		Model: "none",
+		Model: "virtio",
+		Address: &address{
+			Type:     "pci",
+			Domain:   "0x0000",
+			Bus:      "0x00",
+			Slot:     "0x05",
+			Function: "0x00",
+		},
 	}
 
 	if boot.Bios != "" && boot.Cbfs != "" {


### PR DESCRIPTION
208e30f3 is workaroud for the bug of the newest qemu at that time.
but the stable qemu(2.4.1) doesn't have such bug.

revert it. sigh...

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>