### PR TITLE
fix panic on ptyConnect

### DIFF
--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -107,6 +107,7 @@ func (ctx *VmContext) prepareContainer(cmd *NewContainerCommand) *VmContainer {
 		ctx.ptys.attachId++
 	}
 
+	ctx.userSpec.Containers = append(ctx.userSpec.Containers, *cmd.container)
 	ctx.vmSpec.Containers = append(ctx.vmSpec.Containers, *vmContainer)
 
 	ctx.lock.Unlock()


### PR DESCRIPTION
fix issue https://github.com/hyperhq/runv/issues/151

Set containers of userSpec to fix the panic.
Signed-off-by: Gao feng <omarapazanadi@gmail.com>