### PR TITLE
setup pod handler after pod is well associated

### DIFF
--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -104,7 +104,7 @@ func VmAssociate(vmId string, hub chan VmEvent, client chan *types.VmResponse,
 		context.ptys.startStdin(c.Process.Stdio, c.Process.Terminal)
 	}
 
-	context.loop()
+	go context.loop()
 }
 
 func InitNetwork(bIface, bIP string, disableIptables bool) error {

--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -99,7 +99,7 @@ func (vm *Vm) AssociateVm(mypod *PodStatus, data []byte) error {
 		Status   = make(chan *types.VmResponse, 128)
 	)
 
-	go VmAssociate(mypod.Vm, PodEvent, Status, mypod.Wg, data)
+	VmAssociate(mypod.Vm, PodEvent, Status, mypod.Wg, data)
 
 	go vm.handlePodEvent(mypod)
 


### PR DESCRIPTION
In the previous implementation, the associate and handler are two parallel
goroutine. However, the handler goroutine need vmcontext.client to be
precent, which is assigned in the associate goroutine.

In this patch, we associate first, and only let the main loop to be a goroutine.
Then, when the handler start, it must have the vmcontext.client channel ready.

This could guarantee the stop/kill/restart operation still available after re-associate.

Signed-off-by: Xu Wang <gnawux@gmail.com>