### PR TITLE
Print runv-ns-daemon log via glog

### DIFF
--- a/hypervisor/pod/ocf-linux.go
+++ b/hypervisor/pod/ocf-linux.go
@@ -1,9 +1,9 @@
 package pod
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -18,7 +18,7 @@ func ConvertOCF2UserContainer(s *specs.Spec) *UserContainer {
 	}
 
 	for _, value := range s.Process.Env {
-		fmt.Printf("env: %s\n", value)
+		glog.V(1).Infof("env: %s\n", value)
 		values := strings.Split(value, "=")
 		tmp := UserEnvironmentVar{
 			Env:   values[0],

--- a/hypervisor/volume_linux.go
+++ b/hypervisor/volume_linux.go
@@ -47,7 +47,7 @@ func aufsUnmount(target string) error {
 	cmdString := fmt.Sprintf("auplink %s flush", target)
 	cmd := exec.Command("/bin/sh", "-c", cmdString)
 	if err := cmd.Run(); err != nil {
-		glog.Warningf("Couldn't run auplink command : %s\n%s", err.Error())
+		glog.Warningf("Couldn't run auplink command : %s\n", err.Error())
 	}
 	if err := syscall.Unmount(target, 0); err != nil {
 		return err

--- a/start.go
+++ b/start.go
@@ -46,21 +46,18 @@ func loadStartConfig(context *cli.Context) (*startConfig, error) {
 	if !filepath.IsAbs(config.BundlePath) {
 		config.BundlePath, err = filepath.Abs(config.BundlePath)
 		if err != nil {
-			fmt.Printf("Cannot get abs path for bundle path: %s\n", err.Error())
-			return nil, err
+			return nil, fmt.Errorf("Cannot get abs path for bundle path: %s\n", err.Error())
 		}
 	}
 
 	ocffile := filepath.Join(config.BundlePath, specConfig)
 
 	if _, err = os.Stat(ocffile); os.IsNotExist(err) {
-		fmt.Printf("Please make sure bundle directory contains config.json\n")
-		return nil, err
+		return nil, fmt.Errorf("Please make sure bundle directory contains config.json: %v\n", err.Error())
 	}
 
 	ocfData, err := ioutil.ReadFile(ocffile)
 	if err != nil {
-		fmt.Printf("%s\n", err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
runv-ns-daemon will run under daemon mode and print everything to
/dev/null, which will lost useful debug information.
This commit will allow printing all debug message via glog instead of
Printf, keep the useful log information into log files.

PS: I'm not that familiar to Runv, so if it's more suitable to use `glog.V(3)` in some places instead of `V(1)`, feel free to comment. :smile: 

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>