### PR TITLE
support qemu lazy mode

### DIFF
--- a/hypervisor/init_comm.go
+++ b/hypervisor/init_comm.go
@@ -79,6 +79,11 @@ func ReadVmMessage(conn *net.UnixConn) (*DecodedMessage, error) {
 		res = append(res, buf[:nr]...)
 		read = read + nr
 
+		// if condition satisified, message length may wrong , read again
+		if nr < want && read < needRead {
+			return ReadVmMessage(conn)
+		}
+
 		glog.V(1).Infof("read %d/%d [length = %d]", read, needRead, length)
 
 		if length == 0 && read >= 8 {

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -27,6 +27,25 @@ type QemuContext struct {
 	qmpSockName string
 	cpus        int
 	process     *os.Process
+	interfaces 	[]lazyQemuNicConfig
+	images 		[]lazyQemuImageConfig
+	callbacks 	[]hypervisor.VmEvent
+}
+
+//qemu lazy nic configuration
+type lazyQemuNicConfig struct {
+	fd 			uint64
+	deviceName 	string
+	macAddr 	string
+	pciAddr		int
+}
+
+//qemu lazy block configuration
+type lazyQemuImageConfig struct {
+	deviceName 	string
+	sourceType 	string
+	format 		string
+	scsiId 		int
 }
 
 func qemuContext(ctx *hypervisor.VmContext) *QemuContext {
@@ -292,7 +311,7 @@ func (qc *QemuContext) Save(ctx *hypervisor.VmContext, path string, result chan<
 }
 
 func (qc *QemuDriver) SupportLazyMode() bool {
-	return false
+	return true
 }
 
 func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
@@ -341,7 +360,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "\"console=ttyS0 panic=1 no_timer_check\"")
 	}
 
-	return append(params,
+	params = append(params,
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults", "-no-hpet",
 		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams,
@@ -354,4 +373,68 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 		"-fsdev", fmt.Sprintf("local,id=virtio9p,path=%s,security_model=none", ctx.ShareDir),
 		"-device", fmt.Sprintf("virtio-9p-pci,fsdev=virtio9p,mount_tag=%s", hypervisor.ShareDirTag),
 	)
+
+	//lazy add nic device
+	for i, info := range qc.interfaces {
+		params = append(params,
+		"-netdev", fmt.Sprintf("tap,fd=%d,id=%s", info.fd, info.deviceName),
+		"-device", fmt.Sprintf("virtio-net-pci,netdev=%s,id=netchan%d,mac=%s,bus=pci.0,addr=0x%d", info.deviceName, i, info.macAddr, info.pciAddr),
+		)
+	}
+
+	//lazy add block device
+	for _,image := range qc.images {
+		params = append(params,
+		"-drive",fmt.Sprintf("file=%s,if=none,id=drive%d,format=%s,cache=writeback", image.deviceName, image.scsiId, image.format),
+		"-device",fmt.Sprintf("scsi-hd,bus=scsi0.0,drive=drive%d,id=scsi-disk%d,scsi-id=%d", image.scsiId, image.scsiId, image.scsiId),
+		)
+	}
+
+	return params
+}
+
+
+func (qc *QemuContext) LazyAddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo) {
+	callback := &hypervisor.NetDevInsertedEvent {
+		Index:			guest.Index,
+		DeviceName:		guest.Device,
+		Address:		guest.Busaddr,
+	}
+	qc.callbacks = append(qc.callbacks, callback)
+
+	info := lazyQemuNicConfig {
+		fd:				host.Fd,
+		deviceName: 	guest.Device,
+		macAddr:		host.Mac,
+		pciAddr:		guest.Busaddr,
+	}
+	qc.interfaces = append(qc.interfaces, info)
+}
+
+func (qc *QemuContext) LazyAddDisk(ctx *hypervisor.VmContext, name, sourceType, filename, format string, id int) {
+	devName := scsiId2Name(id)
+	callback := &hypervisor.BlockdevInsertedEvent {
+		Name:			name,
+		SourceType:		sourceType,
+		DeviceName:		devName,
+		ScsiId:			id,
+	}
+	qc.callbacks = append(qc.callbacks, callback)
+
+	image := lazyQemuImageConfig {
+		deviceName:		filename,
+		sourceType:		sourceType,
+		format:			format,
+		scsiId:			id,
+	}
+	qc.images = append(qc.images, image)
+}
+
+func (qc *QemuContext) LazyLaunch(ctx *hypervisor.VmContext) {
+	go launchQemu(qc, ctx)
+	go qmpHandler(ctx)
+}
+
+func (qc *QemuContext) InitVM(ctx *hypervisor.VmContext) error {
+	return nil
 }

--- a/hypervisor/qemu/qemu_process.go
+++ b/hypervisor/qemu/qemu_process.go
@@ -79,6 +79,12 @@ func launchQemu(qc *QemuContext, ctx *hypervisor.VmContext) {
 		ctx.Hub <- &hypervisor.VmStartFailEvent{Message: "watch qemu process failed"}
 		return
 	}
+
+	//report device ready, could start pod
+	for _, cb := range qc.callbacks {
+		ctx.Hub <- cb
+	}
+	
 }
 
 func associateQemu(ctx *hypervisor.VmContext) {

--- a/hypervisor/tty.go
+++ b/hypervisor/tty.go
@@ -107,6 +107,11 @@ func readTtyMessage(conn *net.UnixConn) (*ttyMessage, error) {
 		res = append(res, buf[:nr]...)
 		read = read + nr
 
+		// if condition satisified, message length may wrong , read again
+		if nr < want && read < needRead {
+			return readTtyMessage(conn)
+		}
+
 		glog.V(1).Infof("tty: read %d/%d [length = %d]", read, needRead, length)
 
 		if length == 0 && read >= 12 {


### PR DESCRIPTION
  I make qemu match LazyDriverContext and add three items in QemuContext.So we can launch Qemu with net and block device mounted .The "interface" and "image" in QemuContext is used to store the net and block device configuration.The "callbacks" is used to send the event that devices is ready, so we can start pod.
  Unfortunately, there seems a little problem, at the very begining, we may receive a tty or init message with impossible big length message.So, I do a little trick to find and  read the entire wrong message, and start reading again.Then every thing is OK.But I dont know if it is relevant with lazy mode?