### PR TITLE
Fix panic when ctr exec contains no command

### DIFF
--- a/containerd/api/grpc/server/server.go
+++ b/containerd/api/grpc/server/server.go
@@ -73,6 +73,11 @@ func (s *apiServer) AddProcess(ctx context.Context, r *types.AddProcessRequest) 
 	if r.Pid == "" {
 		return nil, fmt.Errorf("process id cannot be empty")
 	}
+
+	if len(r.Args) == 0 {
+		return nil, fmt.Errorf("args cannot be empty")
+	}
+
 	spec := &specs.Process{
 		Terminal: r.Terminal,
 		Args:     r.Args,

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -713,7 +713,7 @@ func stateRunning(ctx *VmContext, ev VmEvent) {
 				cmd := ack.reply.Event.(*ExecCommand)
 				ctx.ptys.Close(cmd.Process.Stdio, 255)
 				ctx.reportExec(ack.reply.Event, true)
-				glog.V(0).Infof("Exec command %s on session %d failed", cmd.Process.Args[0], cmd.Process.Stdio)
+				glog.V(0).Infof("Exec command %v on session %d failed", cmd.Process.Args, cmd.Process.Stdio)
 			} else if ack.reply.Code == INIT_READFILE {
 				ctx.reportFile(ack.reply.Event, INIT_READFILE, ack.msg, true)
 				glog.Infof("Get error for read data: %s", string(ack.msg))


### PR DESCRIPTION
Normal exec should be `ctr exec --id xxx --pid xxx command`, if user
forget to input command, runv-containerd panics.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

Part of panic log:
```
panic: runtime error: index out of range

goroutine 38 [running]:
github.com/hyperhq/runv/hypervisor.stateRunning(0xc820284120, 0x7f64e419d218, 0xc820301360)
	/home/darcy/gocode/src/github.com/hyperhq/runv/hypervisor/vm_states.go:716 +0x1c08
github.com/hyperhq/runv/hypervisor.(*VmContext).loop(0xc820284120)
	/home/darcy/gocode/src/github.com/hyperhq/runv/hypervisor/hypervisor.go:30 +0x4c1
github.com/hyperhq/runv/hypervisor.VmLoop(0xc820226b90, 0xd, 0xc82024c300, 0xc82024c360, 0xc82023eaf0)
	/home/darcy/gocode/src/github.com/hyperhq/runv/hypervisor/hypervisor.go:49 +0x1e9
created by github.com/hyperhq/runv/hypervisor.(*Vm).Launch
	/home/darcy/gocode/src/github.com/hyperhq/runv/hypervisor/vm.go:51 +0x19e

goroutine 1 [chan receive]:
main.daemon(0xc82010f860, 0x24, 0xc820138aa0, 0x14, 0xc820138ac0, 0x15, 0xc820138ae0, 0x1f, 0x0, 0x0)
	/home/darcy/gocode/src/github.com/hyperhq/runv/containerd/main.go:141 +0x3f2
main.main.func1(0xc8200d8780)
	/home/darcy/gocode/src/github.com/hyperhq/runv/containerd/main.go:115 +0x513
github.com/codegangsta/cli.(*App).Run(0xc82008ef20, 0xc82000a120, 0x6, 0x6, 0x0, 0x0)
	/home/darcy/gocode/src/github.com/hyperhq/runv/Godeps/_workspace/src/github.com/codegangsta/cli/app.go:201 +0x13d8
main.main()
	/home/darcy/gocode/src/github.com/hyperhq/runv/containerd/main.go:120 +0xe6

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1696 +0x1

goroutine 5 [syscall]:
os/signal.loop()
	/usr/local/go/src/os/signal/signal_unix.go:22 +0x18
created by os/signal.init.1
	/usr/local/go/src/os/signal/signal_unix.go:28 +0x37

goroutine 9 [chan receive]:
github.com/golang/glog.(*loggingT).flushDaemon(0xf84260)
	/home/darcy/gocode/src/github.com/hyperhq/runv/Godeps/_workspace/src/github.com/golang/glog/glog.go:882 +0x67
created by github.com/golang/glog.init.1
	/home/darcy/gocode/src/github.com/hyperhq/runv/Godeps/_workspace/src/github.com/golang/glog/glog.go:410 +0x297

goroutine 10 [select, locked to thread]:
runtime.gopark(0xb8c938, 0xc820029728, 0xa72340, 0x6, 0x18, 0x2)
	/usr/local/go/src/runtime/proc.go:185 +0x163
runtime.selectgoImpl(0xc820029728, 0x0, 0x18)
	/usr/local/go/src/runtime/select.go:392 +0xa64
runtime.selectgo(0xc820029728)
	/usr/local/go/src/runtime/select.go:212 +0x12
runtime.ensureSigM.func1()
	/usr/local/go/src/runtime/signal1_unix.go:227 +0x353
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1696 +0x1

    ...
```
