### PR TITLE
Adapt to new OCI spec for root

### DIFF
--- a/supervisor/container.go
+++ b/supervisor/container.go
@@ -74,7 +74,9 @@ func (c *Container) run(p *Process) error {
 
 	glog.V(3).Infof("prepare hypervisor info")
 	u := pod.ConvertOCF2UserContainer(c.Spec)
-	u.Image = filepath.Join(c.BundlePath, u.Image)
+	if !filepath.IsAbs(u.Image) {
+		u.Image = filepath.Join(c.BundlePath, u.Image)
+	}
 	vmRootfs := filepath.Join(hypervisor.BaseDir, c.ownerPod.vm.Id, hypervisor.ShareDirTag, c.Id, "rootfs")
 	os.MkdirAll(vmRootfs, 0755)
 


### PR DESCRIPTION
Now docker use absolute bundle root path instead of relative
[$BUNDLE]/rootfs path, and OCI has made relative changes.

Change runv-containerd to adapt this change, or it won't work any more.

See https://github.com/docker/docker/pull/22256 and https://github.com/opencontainers/runtime-spec/pull/394

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>