### PR TITLE
support qemu lazy mode

### DIFF
--- a/hypervisor/qemu/qemu_process.go
+++ b/hypervisor/qemu/qemu_process.go
@@ -79,6 +79,12 @@ func launchQemu(qc *QemuContext, ctx *hypervisor.VmContext) {
 		ctx.Hub <- &hypervisor.VmStartFailEvent{Message: "watch qemu process failed"}
 		return
 	}
+
+	// report device ready, could start pod
+	for _, cb := range qc.callbacks {
+		ctx.Hub <- cb
+	}
+
 }
 
 func associateQemu(ctx *hypervisor.VmContext) {


### PR DESCRIPTION
I make qemu match LazyDriverContext and add three items in QemuContext.So we can launch Qemu with net and block device mounted .The "interface" and "image" in QemuContext is used to store the net and block device configuration.The "callbacks" is used to send the event that devices is ready, after that we can start pod.
