### PR TITLE
don't close the client event listeners until the context is closed

### DIFF
--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -73,7 +73,6 @@ func (vm *Vm) Kill() (int, string, error) {
 		Response, ok = <-Status
 		if !ok || Response == nil || Response.Code == types.E_VM_SHUTDOWN {
 			vm.ReleaseResponseChan(Status)
-			vm.clients.Close()
 			vm.clients = nil
 			stop = true
 		}
@@ -193,7 +192,6 @@ func (vm *Vm) handlePodEvent(mypod *PodStatus) {
 
 		exit := mypod.Handler.Handle(Response, mypod.Handler.Data, mypod, vm)
 		if exit {
-			vm.clients.Close()
 			vm.clients = nil
 			break
 		}


### PR DESCRIPTION
ctx.Close() will close the upstream of the clients, so event listeners
(and Fanout) are closed in consequence.

So that all the event listeners can listen all the event until end.

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>