### PR TITLE
Disable libnetwork prestart hook

### DIFF
--- a/supervisor/container.go
+++ b/supervisor/container.go
@@ -240,6 +240,12 @@ func execHook(hook specs.Hook, state *specs.State) error {
 
 func execPrestartHooks(rt *specs.Spec, state *specs.State) error {
 	for _, hook := range rt.Hooks.Prestart {
+		// FIXME: we don't support libnetwork now, so we skip libnetwork prestart hook
+		// Remove this if one day we finally support CNM
+		if len(hook.Args) > 0 && hook.Args[0] == "libnetwork-setkey" {
+			glog.V(3).Infof("Skip libnetwork-setkey because we don't support libnetwork currently")
+			continue
+		}
 		err := execHook(hook, state)
 		if err != nil {
 			return err


### PR DESCRIPTION
Disable libnetwork-setkey prestart hook right now because actually we
don't support CNM. Before this, if we don't specify `--net none` in docker
command line, something weird will happen, you can see container running
with ps, but you can exec/stop/rm that container, this will influence
user experience largely.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>