### PR TITLE
travis-ci: move build runv to the before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,10 @@ before_install:
   - tar xf lvm2-2_02_131.tar.xz
   - cd lvm2-2_02_131
   - ./configure && make device-mapper && sudo make install
-
-script:
   - cd ${TRAVIS_BUILD_DIR}
   - hack/verify-gofmt.sh
   - hack/validate-vet.sh
-  - ./autogen.sh
-  - ./configure
-  - make
-  - hack/test-cmd.sh
+  - ./autogen.sh && ./configure && make
+
+script:
+  - cd ${TRAVIS_BUILD_DIR} && hack/test-cmd.sh


### PR DESCRIPTION
If commands in before_script return a non-zero exit code,
travis will stop immediately, this will give us explicit
error message.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>