### PR TITLE
add simple comments for the build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ The current release of `runV` supports the following distros:
 
 ### Build
 ```bash
+# install autoconf automake pkg-config make gcc golang qemu
+# optional install device-mapper and device-mapper-devel for device-mapper storage
+# optional install xen and xen-devel for xen driver
+# optional install libvirt and libvirt-devel for libvirt driver
+# note: the above package names might be different in various distros
 # create a 'github.com/hyperhq' in your GOPATH/src
 cd $GOPATH/src/github.com/hyperhq
 git clone https://github.com/hyperhq/runv/


### PR DESCRIPTION
the verbose build dependencies will be added to
http://docs.hypercontainer.io (github.com/hyperhq/book) later.

fix #1

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>