### PR TITLE
Omit error when it has empty msg

### DIFF
--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -16,6 +16,10 @@ import (
 	"github.com/hyperhq/runv/hypervisor/types"
 )
 
+const (
+	vmNoFileReadError = "Error: "
+)
+
 type Vm struct {
 	Id     string
 	Pod    *PodStatus
@@ -348,6 +352,11 @@ func (vm *Vm) ReadFile(container, target string) ([]byte, error) {
 		cmd.result = result
 		ctx.vm <- &cmd
 	}, StateRunning)
+
+	// if we got a error with empty content, omit it: it's a container without service
+	if err != nil && err.Error() == vmNoFileReadError {
+		err = nil
+	}
 
 	return cmd.retMsg, err
 }


### PR DESCRIPTION
When there's no service defined in Pod spec, `ListService` will receive a error with empty msg returned by `ReadFile`, it's obscure and hard to debug.

How to reproduce:
`ListService` for any Pod without service discovery defined.