### PR TITLE
update `runv start` command line and the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,36 @@ root         2  0.0  0.5   4448   632 pts/0    Ss   05:54   0:00 sh
 root         4  0.0  1.6  15572  2032 pts/0    R+   05:57   0:00 ps aux
 ```
 
+### Run it with docker
+`runv` is a runtime implementation of [OCI](https://github.com/opencontainers/runtime-spec) and its commandline is partially compatible with the runc commandline. (it is compatible with the commandline of the docker-runc of the docker-1.1 currently, so official docker-1.1 binary works in the example)
+
+Note, runv project also provides [other way](https://github.com/hyperhq/runv/tree/master/containerd) to integrate with docker.
+Note, container tty is not working currently.
+
+```bash
+# in terminal #1
+docker-containerd --debug -l /var/run/docker/libcontainerd/docker-containerd.sock \
+  --runtime /path/to/runv --runtime-args --debug --runtime-args --driver=libvirt \
+  --runtime-args --kernel=/opt/hyperstart/build/kernel \
+  --runtime-args --initrd=/opt/hyperstart/build/hyper-initrd.img \
+  --start-timeout 2m
+# in terminal #2
+docker daemon -D -l debug --containerd=/var/run/docker/libcontainerd/docker-containerd.sock
+# in terminal #3 for trying it
+docker run  busybox ls
+bin
+dev
+etc
+home
+lib
+proc
+root
+sys
+tmp
+usr
+var
+```
+
 ### Example
 Please check the runC example to get the container rootfs.
 https://github.com/opencontainers/runc#examples

--- a/containerd/main.go
+++ b/containerd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperhq/runv/factory"
 	"github.com/hyperhq/runv/hypervisor"
 	"github.com/hyperhq/runv/supervisor"
+	"github.com/hyperhq/runv/supervisor/proxy"
 	"google.golang.org/grpc"
 )
 
@@ -84,7 +85,7 @@ var daemonFlags = []cli.Flag{
 
 func main() {
 	if os.Args[0] == "containerd-nslistener" {
-		nsListenerDaemon()
+		proxy.NsListenerDaemon()
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/containerd/api/grpc/types"
+	"github.com/hyperhq/runv/supervisor/proxy"
 	netcontext "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
@@ -50,6 +51,11 @@ If not specified, the default value for the 'bundle' is the current directory.
 func main() {
 	if os.Args[0] == "runv-namespaced" {
 		runvNamespaceDaemon()
+		os.Exit(0)
+	}
+
+	if os.Args[0] == "containerd-nslistener" {
+		proxy.NsListenerDaemon()
 		os.Exit(0)
 	}
 

--- a/supervisor/proxy/nslistener.go
+++ b/supervisor/proxy/nslistener.go
@@ -1,4 +1,4 @@
-package main
+package proxy
 
 import (
 	"encoding/gob"
@@ -10,7 +10,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func nsListenerDaemon() {
+func NsListenerDaemon() {
 	/* create own netns */
 	if err := syscall.Unshare(syscall.CLONE_NEWNET); err != nil {
 		glog.Error(err)


### PR DESCRIPTION
make it partially compatible with the docker-runc of docker-1.11
fix unfinished part of #178

