### PR TITLE
Bug fix: runv-contianerd hangs when no terminal

### DIFF
--- a/hypervisor/tty.go
+++ b/hypervisor/tty.go
@@ -22,6 +22,7 @@ type WindowSize struct {
 type TtyIO struct {
 	Stdin     io.ReadCloser
 	Stdout    io.WriteCloser
+	Stderr    io.WriteCloser
 	ClientTag string
 	Callback  chan *types.VmResponse
 	ExitCode  uint8
@@ -238,6 +239,10 @@ func (tty *TtyIO) Close(code uint8) string {
 	if tty.Stdout != nil {
 		tty.Stdout.Close()
 	}
+	if tty.Stderr != nil {
+		tty.Stderr.Close()
+	}
+
 	if tty.Callback != nil {
 		tty.Callback <- &types.VmResponse{
 			Code:  types.E_EXEC_FINISH,

--- a/supervisor/process.go
+++ b/supervisor/process.go
@@ -47,6 +47,11 @@ func (p *Process) setupIO() error {
 	if err != nil {
 		return err
 	}
+	stderr, err := os.OpenFile(p.Stderr, syscall.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+
 	// TODO: setup stderr
 	if p.Spec.Terminal {
 	}
@@ -54,6 +59,7 @@ func (p *Process) setupIO() error {
 		ClientTag: p.inerId,
 		Stdin:     stdin,
 		Stdout:    stdout,
+		Stderr:    stderr,
 		Callback:  make(chan *types.VmResponse, 1),
 	}
 	glog.Infof("process setupIO() success")


### PR DESCRIPTION
Fixes https://github.com/hyperhq/runv/issues/210

When trying to interact between docker and runv-containerd, if docker
specify no terminal, client can't exit and everything hangs.

This is caused by blocked stderr pipe, if docker specify no terminal,
docker will open reader side of stderr pipe, but runv-containerd never
open write side of stderr side, which causes everything to hanging
state.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>