### PR TITLE
use UserVolume to describe container image

### DIFF
--- a/hypervisor/devicemap.go
+++ b/hypervisor/devicemap.go
@@ -170,16 +170,25 @@ func (ctx *VmContext) setContainerInfo(index int, container *hyperstartapi.Conta
 	container.Initialize = info.Initialize
 
 	if info.Fstype == "dir" {
-		container.Image = info.Image
+		container.Image = info.Image.Source
 		container.Fstype = ""
 	} else {
 		container.Fstype = info.Fstype
-		ctx.devices.imageMap[info.Image] = &imageInfo{
+		ctx.devices.imageMap[info.Image.Source] = &imageInfo{
 			info: &BlockDescriptor{
-				Name: info.Image, Filename: info.Image, Format: "raw", Fstype: info.Fstype, DeviceName: ""},
+				Name:       info.Image.Source,
+				Filename:   info.Image.Source,
+				Format:     "raw",
+				Fstype:     info.Fstype,
+				DeviceName: "",
+				Options: map[string]string{
+					"user":     info.Image.Option.User,
+					"keyring":  info.Image.Option.Keyring,
+					"monitors": strings.Join(info.Image.Option.Monitors, ";"),
+				}},
 			pos: index,
 		}
-		ctx.progress.adding.blockdevs[info.Image] = true
+		ctx.progress.adding.blockdevs[info.Image.Source] = true
 	}
 }
 

--- a/hypervisor/events.go
+++ b/hypervisor/events.go
@@ -99,7 +99,7 @@ type ContainerInfo struct {
 	User    string
 	MountId string
 	Rootfs  string
-	Image   string // if fstype is `dir`, this should be a path relative to share_dir
+	Image   pod.UserVolume // if fstype is `dir`, this should be a path relative to share_dir
 	// which described the mounted aufs or overlayfs dir.
 	Fstype     string
 	Workdir    string

--- a/supervisor/container.go
+++ b/supervisor/container.go
@@ -122,7 +122,7 @@ func (c *Container) start(p *Process) error {
 	info := &hypervisor.ContainerInfo{
 		Id:     c.Id,
 		Rootfs: "rootfs",
-		Image:  c.Id,
+		Image:  pod.UserVolume{Source: c.Id},
 		Fstype: "dir",
 		Cmd:    u.Command,
 		Envs:   envs,


### PR DESCRIPTION
So that it can describe complex rootfs volume like an rbd based one.

Signed-off-by: Peng Tao <bergwolf@gmail.com>