### PR TITLE
add rbd IO throttle support

### DIFF
--- a/hypervisor/devicemap.go
+++ b/hypervisor/devicemap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -182,12 +183,15 @@ func (ctx *VmContext) setContainerInfo(index int, container *hyperstartapi.Conta
 				Fstype:     info.Fstype,
 				DeviceName: "",
 				Options: map[string]string{
-					"user":     info.Image.Option.User,
-					"keyring":  info.Image.Option.Keyring,
-					"monitors": strings.Join(info.Image.Option.Monitors, ";"),
+					"user":        info.Image.Option.User,
+					"keyring":     info.Image.Option.Keyring,
+					"monitors":    strings.Join(info.Image.Option.Monitors, ";"),
+					"bytespersec": strconv.Itoa(info.Image.Option.BytesPerSec),
+					"iops":        strconv.Itoa(info.Image.Option.Iops),
 				}},
 			pos: index,
 		}
+		glog.V(1).Infof("insert volume %s source %s fstype %s", info.Image.Source, info.Image.Source, info.Fstype)
 		ctx.progress.adding.blockdevs[info.Image.Source] = true
 	}
 }
@@ -240,6 +244,14 @@ func (ctx *VmContext) initVolumeMap(spec *pod.UserPod) {
 					"keyring":  vol.Option.Keyring,
 					"monitors": strings.Join(vol.Option.Monitors, ";"),
 				},
+			}
+			if vol.Option.BytesPerSec != 0 {
+				bytes := strconv.Itoa(vol.Option.BytesPerSec)
+				v.info.Options["bytespersec"] = bytes
+			}
+			if vol.Option.Iops != 0 {
+				iops := strconv.Itoa(vol.Option.Iops)
+				v.info.Options["iops"] = iops
 			}
 			ctx.devices.volumeMap[vol.Name] = v
 			ctx.progress.adding.blockdevs[vol.Name] = true

--- a/hypervisor/devicemap.go
+++ b/hypervisor/devicemap.go
@@ -170,16 +170,25 @@ func (ctx *VmContext) setContainerInfo(index int, container *hyperstartapi.Conta
 	container.Initialize = info.Initialize
 
 	if info.Fstype == "dir" {
-		container.Image = info.Image
+		container.Image = info.Image.Source
 		container.Fstype = ""
 	} else {
 		container.Fstype = info.Fstype
-		ctx.devices.imageMap[info.Image] = &imageInfo{
+		ctx.devices.imageMap[info.Image.Source] = &imageInfo{
 			info: &BlockDescriptor{
-				Name: info.Image, Filename: info.Image, Format: "raw", Fstype: info.Fstype, DeviceName: ""},
+				Name:       info.Image.Source,
+				Filename:   info.Image.Source,
+				Format:     "raw",
+				Fstype:     info.Fstype,
+				DeviceName: "",
+				Options: map[string]string{
+					"user":     info.Image.Option.User,
+					"keyring":  info.Image.Option.Keyring,
+					"monitors": strings.Join(info.Image.Option.Monitors, ";"),
+				}},
 			pos: index,
 		}
-		ctx.progress.adding.blockdevs[info.Image] = true
+		ctx.progress.adding.blockdevs[info.Image.Source] = true
 	}
 }
 

--- a/hypervisor/events.go
+++ b/hypervisor/events.go
@@ -99,7 +99,7 @@ type ContainerInfo struct {
 	User    string
 	MountId string
 	Rootfs  string
-	Image   string // if fstype is `dir`, this should be a path relative to share_dir
+	Image   pod.UserVolume // if fstype is `dir`, this should be a path relative to share_dir
 	// which described the mounted aufs or overlayfs dir.
 	Fstype     string
 	Workdir    string

--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -667,6 +667,11 @@ type disktgt struct {
 	Bus string `xml:"bus,attr"`
 }
 
+type iotune struct {
+	BytesPerSec int `xml:"total_bytes_sec,omitempty"`
+	Iops        int `xml:"total_iops_sec,omitempty"`
+}
+
 type disk struct {
 	XMLName xml.Name    `xml:"disk"`
 	Type    string      `xml:"type,attr"`
@@ -676,6 +681,7 @@ type disk struct {
 	Target  disktgt     `xml:"target"`
 	Address *address    `xml:"address"`
 	Auth    *cephauth   `xml:"auth,omitempty"`
+	Iotune  iotune      `xml:"iotune,omitempty"`
 }
 
 func diskXml(blockInfo *hypervisor.BlockDescriptor, secretUUID string) (string, error) {
@@ -730,6 +736,14 @@ func diskXml(blockInfo *hypervisor.BlockDescriptor, secretUUID string) (string, 
 				Name: hostport[0],
 				Port: hostport[1],
 			})
+		}
+
+		if limit, ok := blockInfo.Options["bytespersec"]; ok {
+			d.Iotune.BytesPerSec, _ = strconv.Atoi(limit)
+		}
+
+		if limit, ok := blockInfo.Options["iops"]; ok {
+			d.Iotune.Iops, _ = strconv.Atoi(limit)
 		}
 
 	} else {

--- a/hypervisor/pod/pod.go
+++ b/hypervisor/pod/pod.go
@@ -78,9 +78,11 @@ type UserFile struct {
 }
 
 type UserVolumeOption struct {
-	Monitors []string `json:"monitors"`
-	User     string   `json:"user"`
-	Keyring  string   `json:"keyring"`
+	Monitors    []string `json:"monitors"`
+	User        string   `json:"user"`
+	Keyring     string   `json:"keyring"`
+	BytesPerSec int      `json:"bytespersec"`
+	Iops        int      `json:"iops"`
 }
 
 type UserVolume struct {

--- a/supervisor/container.go
+++ b/supervisor/container.go
@@ -122,7 +122,7 @@ func (c *Container) start(p *Process) error {
 	info := &hypervisor.ContainerInfo{
 		Id:     c.Id,
 		Rootfs: "rootfs",
-		Image:  c.Id,
+		Image:  pod.UserVolume{Source: c.Id},
 		Fstype: "dir",
 		Cmd:    u.Command,
 		Envs:   envs,


### PR DESCRIPTION
Add bytespersec and iops options in pod rbd volume spec.
And pass them to libvirt to throttle device IO speed.

This is based on https://github.com/hyperhq/runv/pull/269