### PR TITLE
Update runv version

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	version    = "0.4.0"
+	version    = "0.6.0"
 	specConfig = "config.json"
 	stateJson  = "state.json"
 	usage      = `Open Container Initiative hypervisor-based runtime


### PR DESCRIPTION
It's 0.6.0 now.

Signed-off-by: Yang Hongyang <hongyang.yang@easystack.cn>