### PR TITLE
Enable CNI

### DIFF
--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -441,6 +441,15 @@ func (vm *Vm) AddNic(idx int, name string, info pod.UserInterface) error {
 	}, StateRunning)
 }
 
+func (vm *Vm) DeleteNic(idx int) error {
+
+	vm.SendGenericOperation("NetDevRemovedEvent", func(ctx *VmContext, result chan<- error) {
+		ctx.removeInterfaceByLinkIndex(idx)
+	}, StateRunning)
+
+	return nil
+}
+
 // TODO: deprecated api, it will be removed after the hyper.git updated
 func (vm *Vm) AddCpu(totalCpu int) error {
 	return vm.SetCpus(totalCpu)

--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -450,6 +450,16 @@ func (vm *Vm) DeleteNic(idx int) error {
 	return nil
 }
 
+func (vm *Vm) GetNextNicNameInVM() string {
+	name := make(chan string, 1)
+
+	vm.SendGenericOperation("GetNextNicName", func(ctx *VmContext, result chan<- error) {
+		ctx.GetNextNicName(name)
+	}, StateRunning)
+
+	return <-name
+}
+
 // TODO: deprecated api, it will be removed after the hyper.git updated
 func (vm *Vm) AddCpu(totalCpu int) error {
 	return vm.SetCpus(totalCpu)

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -564,6 +564,9 @@ func stateRunning(ctx *VmContext, ev VmEvent) {
 			}
 		case COMMAND_GET_POD_STATS:
 			ctx.reportPodStats(ev)
+		case EVENT_INTERFACE_EJECTED:
+			ctx.releaseNetworkByLinkIndex((ev.(*NetDevRemovedEvent)).Index)
+			glog.V(1).Info("releaseNetworkByLinkIndex:", (ev.(*NetDevRemovedEvent)).Index)
 		default:
 			unexpectedEventHandler(ctx, ev, "pod running")
 		}

--- a/supervisor/hyperpod.go
+++ b/supervisor/hyperpod.go
@@ -248,7 +248,13 @@ func (hp *HyperPod) nsListenerStrap() {
 				Ip:     update.Addr.LinkAddress.String(),
 			}
 
-			err = hp.vm.AddNic(update.Addr.LinkIndex, "eth1", conf)
+			nicName := hp.vm.GetNextNicNameInVM()
+			if nicName == "" {
+				glog.Errorf("Can not get proper nic name")
+				continue
+			}
+
+			err = hp.vm.AddNic(update.Addr.LinkIndex, nicName, conf)
 			if err != nil {
 				glog.Error(err)
 				continue

--- a/supervisor/hyperpod.go
+++ b/supervisor/hyperpod.go
@@ -18,6 +18,28 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+type NetlinkUpdateType string
+
+const (
+	UpdateTypeLink  NetlinkUpdateType = "link"
+	UpdateTypeAddr  NetlinkUpdateType = "addr"
+	UpdateTypeRoute NetlinkUpdateType = "route"
+)
+
+// NetlinkUpdate tracks the change of network namespace.
+type NetlinkUpdate struct {
+	// AddrUpdate is used to pass information back from AddrSubscribe()
+	Addr netlink.AddrUpdate
+	// RouteUpdate is used to pass information back from RouteSubscribe()
+	Route netlink.RouteUpdate
+	// Veth is used to pass information back from LinkSubscribe().
+	// We only support veth link at present.
+	Veth *netlink.Veth
+
+	// UpdateType indicates which part of the netlink infomation has been changed.
+	UpdateType NetlinkUpdateType
+}
+
 type HyperPod struct {
 	Containers map[string]*Container
 	Processes  map[string]*Process
@@ -102,6 +124,7 @@ func (hp *HyperPod) initPodNetwork(c *Container) error {
 
 	/* send collect netns request to nsListener */
 	if err := listener.enc.Encode("init"); err != nil {
+		glog.Error("listener.dec.Decode init error:", err)
 		return err
 	}
 
@@ -109,12 +132,14 @@ func (hp *HyperPod) initPodNetwork(c *Container) error {
 	/* read nic information of ns from pipe */
 	err := listener.dec.Decode(&infos)
 	if err != nil {
+		glog.Error("listener.dec.Decode infos error:", err)
 		return err
 	}
 
 	routes := []netlink.Route{}
 	err = listener.dec.Decode(&routes)
 	if err != nil {
+		glog.Error("listener.dec.Decode route error:", err)
 		return err
 	}
 
@@ -141,6 +166,9 @@ func (hp *HyperPod) initPodNetwork(c *Container) error {
 			conf.Gw = gw_route.Gw.String()
 		}
 
+		// TODO(hukeping): the name here is alwasy eth1, 2, 3, 4, 5, etc.,
+		// which would not be the proper way to name device name, instead it
+		// should be the same as what we specified in the network namespace.
 		err = hp.vm.AddNic(info.Index, fmt.Sprintf("eth%d", idx), conf)
 		if err != nil {
 			glog.Error(err)
@@ -153,13 +181,77 @@ func (hp *HyperPod) initPodNetwork(c *Container) error {
 		glog.Error(err)
 		return err
 	}
-	/*
-		go func() {
-			// watching container network setting, update vm/hyperstart
-		}()
-	*/
+
+	go hp.nsListenerStrap()
 
 	return nil
+}
+
+func (hp *HyperPod) nsListenerStrap() {
+	listener := hp.nslistener
+
+	// Keep watching container network setting
+	// and then update vm/hyperstart
+	for {
+		update := NetlinkUpdate{}
+		err := listener.dec.Decode(&update)
+		if err != nil {
+			glog.Error("listener.dec.Decode NetlinkUpdate error:", err)
+			continue
+		}
+
+		glog.Info("network namespace information of ", update.UpdateType, " has been changed")
+		switch update.UpdateType {
+		case UpdateTypeLink:
+			link := update.Veth
+			if link.Attrs().ParentIndex == 0 {
+				glog.Info("The deleted link :", link)
+			} else {
+				glog.Info("The changed link :", link)
+			}
+
+		case UpdateTypeAddr:
+			glog.Info("The changed address :", update.Addr)
+
+			link := update.Veth
+
+			// If there is a delete operation upon an link, it will also trigger
+			// the address change event which the link will be NIL since it has
+			// already been deleted before the address change event be triggered.
+			if link == nil {
+				glog.Info("Link seems has already been deleted, please check.")
+				continue
+			}
+
+			// This is just a sanity check.
+			//
+			// The link should be the one which the address on it has been changed.
+			if link.Attrs().Index != update.Addr.LinkIndex {
+				glog.Errorf("Get the wrong link with ID %d, expect %d", link.Attrs().Index, update.Addr.LinkIndex)
+				continue
+			}
+
+			bridge, err := GetBridgeFromIndex(link.Attrs().ParentIndex)
+			if err != nil {
+				glog.Error(err)
+				continue
+			}
+
+			conf := pod.UserInterface{
+				Bridge: bridge,
+				Ip:     update.Addr.LinkAddress.String(),
+			}
+
+			err = hp.vm.AddNic(update.Addr.LinkIndex, link.Attrs().Name, conf)
+			if err != nil {
+				glog.Error(err)
+				continue
+			}
+
+		case UpdateTypeRoute:
+
+		}
+	}
 }
 
 func newPipe() (parent, child *os.File, err error) {

--- a/supervisor/hyperpod.go
+++ b/supervisor/hyperpod.go
@@ -206,6 +206,12 @@ func (hp *HyperPod) nsListenerStrap() {
 			link := update.Veth
 			if link.Attrs().ParentIndex == 0 {
 				glog.Info("The deleted link :", link)
+				err = hp.vm.DeleteNic(link.Attrs().Index)
+				if err != nil {
+					glog.Error(err)
+					continue
+				}
+
 			} else {
 				glog.Info("The changed link :", link)
 			}
@@ -219,7 +225,7 @@ func (hp *HyperPod) nsListenerStrap() {
 			// the address change event which the link will be NIL since it has
 			// already been deleted before the address change event be triggered.
 			if link == nil {
-				glog.Info("Link seems has already been deleted, please check.")
+				glog.Info("Link for this address has already been deleted.")
 				continue
 			}
 
@@ -242,7 +248,7 @@ func (hp *HyperPod) nsListenerStrap() {
 				Ip:     update.Addr.LinkAddress.String(),
 			}
 
-			err = hp.vm.AddNic(update.Addr.LinkIndex, link.Attrs().Name, conf)
+			err = hp.vm.AddNic(update.Addr.LinkIndex, "eth1", conf)
 			if err != nil {
 				glog.Error(err)
 				continue

--- a/supervisor/proxy/nslistener.go
+++ b/supervisor/proxy/nslistener.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"encoding/gob"
+	"fmt"
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/golang/glog"
@@ -11,6 +13,13 @@ import (
 )
 
 func NsListenerDaemon() {
+	setupNsListener()
+}
+
+func setupNsListener() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	/* create own netns */
 	if err := syscall.Unshare(syscall.CLONE_NEWNET); err != nil {
 		glog.Error(err)
@@ -39,6 +48,7 @@ func NsListenerDaemon() {
 		return
 	}
 
+	// Get network namespace info for the first time and send to the containerd
 	/* get route info before link down */
 	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
@@ -58,11 +68,15 @@ func NsListenerDaemon() {
 		return
 	}
 
-	/* TODO: watch network setting */
-	var exit string
-	if err := dec.Decode(&exit); err != nil {
-		glog.Error(err)
+	// This is a call back function.
+	// Use to send netlink update informations to containerd.
+	netNs2Containerd := func(netlinkUpdate supervisor.NetlinkUpdate) {
+		if err := enc.Encode(netlinkUpdate); err != nil {
+			glog.Info("err Encode(netlinkUpdate) is :", err)
+		}
 	}
+	// Keep collecting network namespace info and sending to the containerd
+	setupNetworkNsTrap(netNs2Containerd)
 }
 
 func collectionInterfaceInfo() []supervisor.InterfaceInfo {
@@ -95,8 +109,137 @@ func collectionInterfaceInfo() []supervisor.InterfaceInfo {
 			glog.Infof("get interface %v", info)
 			infos = append(infos, info)
 		}
+
 		// set link down, tap device take over it
 		netlink.LinkSetDown(link)
 	}
 	return infos
+}
+
+// This function should be put into the main process or somewhere that can be
+// use to init the network namespace trap.
+func setupNetworkNsTrap(netNs2Containerd func(supervisor.NetlinkUpdate)) {
+
+	// Subscribe for links change event
+	chLink := make(chan netlink.LinkUpdate)
+	doneLink := make(chan struct{})
+	defer close(doneLink)
+	if err := netlink.LinkSubscribe(chLink, doneLink); err != nil {
+		glog.Fatal(err)
+	}
+
+	// Subscribe for addresses change event
+	chAddr := make(chan netlink.AddrUpdate)
+	doneAddr := make(chan struct{})
+	defer close(doneAddr)
+	if err := netlink.AddrSubscribe(chAddr, doneAddr); err != nil {
+		glog.Fatal(err)
+	}
+
+	// Subscribe for route change event
+	chRoute := make(chan netlink.RouteUpdate)
+	doneRoute := make(chan struct{})
+	defer close(doneRoute)
+	if err := netlink.RouteSubscribe(chRoute, doneRoute); err != nil {
+		glog.Fatal(err)
+	}
+
+	for {
+		select {
+		case updateLink := <-chLink:
+			handleLink(updateLink, netNs2Containerd)
+		case updateAddr := <-chAddr:
+			handleAddr(updateAddr, netNs2Containerd)
+		case updateRoute := <-chRoute:
+			handleRoute(updateRoute, netNs2Containerd)
+		}
+	}
+}
+
+// Link specific
+func handleLink(update netlink.LinkUpdate, callback func(supervisor.NetlinkUpdate)) {
+	if update.IfInfomsg.Flags&syscall.IFF_UP == 1 {
+		fmt.Printf("[Link device up]\tupdateLink is:%+v, flag is:0x%x\n", update.Link.Attrs(), update.IfInfomsg.Flags)
+	} else {
+		if update.Link.Attrs().ParentIndex == 0 {
+			fmt.Printf("[Link device !up][Deleted]\tupdateLink is:%+v, flag is:0x%x\n", update.Link.Attrs(), update.IfInfomsg.Flags)
+		} else {
+			fmt.Printf("[Link device !up]\tupdateLink is:%+v, flag is:0x%x\n", update.Link.Attrs(), update.IfInfomsg.Flags)
+		}
+	}
+
+	netlinkUpdate := supervisor.NetlinkUpdate{}
+	netlinkUpdate.UpdateType = supervisor.UpdateTypeLink
+
+	// We would like to only handle the veth pair link at present.
+	if veth, ok := (update.Link).(*netlink.Veth); ok {
+		netlinkUpdate.Veth = veth
+		callback(netlinkUpdate)
+	}
+}
+
+// Address specific
+func handleAddr(update netlink.AddrUpdate, callback func(supervisor.NetlinkUpdate)) {
+	if update.NewAddr {
+		fmt.Printf("[Add a address]")
+	} else {
+		fmt.Printf("[Delete a address]")
+	}
+
+	if update.LinkAddress.IP.To4() != nil {
+		fmt.Printf("[IPv4]\t%+v\n", update)
+	} else {
+		// We would not like to handle IPv6 at present.
+		fmt.Printf("[IPv6]\t%+v\n", update)
+		return
+	}
+
+	netlinkUpdate := supervisor.NetlinkUpdate{}
+	netlinkUpdate.Addr = update
+	netlinkUpdate.UpdateType = supervisor.UpdateTypeAddr
+	links, err := netlink.LinkList()
+	if err != nil {
+		glog.Error(err)
+	}
+	for _, link := range links {
+		if link.Attrs().Index == update.LinkIndex && link.Type() == "veth" {
+			netlinkUpdate.Veth = link.(*netlink.Veth)
+			break
+		}
+	}
+	callback(netlinkUpdate)
+}
+
+// Route specific
+func handleRoute(update netlink.RouteUpdate, callback func(supervisor.NetlinkUpdate)) {
+	// Route type is not a bit mask for a couple of values, but a single
+	// unsigned int, that's why we use switch here not the "&" operator.
+	switch update.Type {
+	case syscall.RTM_NEWROUTE:
+		fmt.Printf("[Create a route]\t%+v\n", update)
+	case syscall.RTM_DELROUTE:
+		fmt.Printf("[Remove a route]\t%+v\n", update)
+	case syscall.RTM_GETROUTE:
+		fmt.Printf("[Receive info of a route]\t%+v\n", update)
+	}
+
+	netlinkUpdate := supervisor.NetlinkUpdate{}
+	netlinkUpdate.Route = update
+	netlinkUpdate.UpdateType = supervisor.UpdateTypeRoute
+	callback(netlinkUpdate)
+}
+
+// HandleRTNetlinkChange handle the rtnetlink change event and do some verification.
+func HandleRTNetlinkChange(linkIndex int, callback func()) {
+	if err := sanityChecks(); err != nil {
+		fmt.Println("Error happen when doing sanity check, error:", err)
+		return
+	}
+
+	callback()
+}
+
+// Maybe some sanity check and some verifications
+func sanityChecks() error {
+	return nil
 }


### PR DESCRIPTION
The test script would be:
```
#! /bin/bash

set -x
set -e

# it is unlikely we'd use the notary
unset DOCKER_CONTENT_TRUST

# contaienrID of course.
CID=`docker run -d ubuntu:14.04 sleep 10000`

PID=`docker inspect -f "{{.State.Pid}}" $CID`

DEVICE_NAME="eth1"

# Use the bridge Ip, "docker0" for example, as the default gateway for container
Bridge=docker0
#BridgeIP=`ifconfig $Bridge | grep inet | grep -v inet6 | awk '{print $2}' |tr -d "addr:"`
BridgeIP="172.17.0.1"


mkdir -p /var/run/netns

# /var/run/netns/xxx is what `ip` wanted.
ln -s /proc/$PID/ns/net /var/run/netns/$PID

# set up veth pair A and B, attach A to bridge-docker0.
ip link add A type veth peer name B
brctl addif $Bridge A
ip link set A up

# add B into container's network namespace and hack it.
ip link set B netns $PID
ip netns exec $PID ip link set dev B name $DEVICE_NAME
ip netns exec $PID ip link set $DEVICE_NAME address 12:34:56:78:9a:bb
ip netns exec $PID ip addr add 172.17.42.101/16 dev $DEVICE_NAME
ip netns exec $PID ip link set $DEVICE_NAME up
#ip netns exec $PID ip route add default via $BridgeIP

# just in case we want do some thing
sleep 30

ip netns exec $PID ip link delete $DEVICE_NAME
sleep 30

# teardown
docker stop $CID
docker rm $CID

find -L /var/run/netns -type l -delete
ip link delete A
```