### PR TITLE
enable template for runv and runv-containerd

### DIFF
--- a/factory/template/template.go
+++ b/factory/template/template.go
@@ -16,16 +16,16 @@ type templateFactory struct {
 	s *template.TemplateVmState
 }
 
-func New(templatePath string, cpu, mem int, kernel, initrd string) base.Factory {
+func New(templateRoot string, cpu, mem int, kernel, initrd string) base.Factory {
 	var vmName string
 
 	for {
 		vmName = fmt.Sprintf("template-vm-%s", pod.RandStr(10, "alpha"))
-		if _, err := os.Stat(templatePath + "/" + vmName); os.IsNotExist(err) {
+		if _, err := os.Stat(templateRoot + "/" + vmName); os.IsNotExist(err) {
 			break
 		}
 	}
-	s, err := template.CreateTemplateVM(templatePath, vmName, cpu, mem, kernel, initrd)
+	s, err := template.CreateTemplateVM(templateRoot + "/" + vmName, vmName, cpu, mem, kernel, initrd)
 	if err != nil {
 		glog.Infof("failed to create template factory: %v", err)
 		glog.Infof("use direct factory instead")

--- a/factory/template/template.go
+++ b/factory/template/template.go
@@ -13,7 +13,7 @@ import (
 )
 
 type templateFactory struct {
-	s *template.TemplateVmState
+	s *template.TemplateVmConfig
 }
 
 func New(templateRoot string, cpu, mem int, kernel, initrd string) base.Factory {
@@ -25,7 +25,7 @@ func New(templateRoot string, cpu, mem int, kernel, initrd string) base.Factory 
 			break
 		}
 	}
-	s, err := template.CreateTemplateVM(templateRoot + "/" + vmName, vmName, cpu, mem, kernel, initrd)
+	s, err := template.CreateTemplateVM(templateRoot+"/"+vmName, vmName, cpu, mem, kernel, initrd)
 	if err != nil {
 		glog.Infof("failed to create template factory: %v", err)
 		glog.Infof("use direct factory instead")
@@ -34,7 +34,7 @@ func New(templateRoot string, cpu, mem int, kernel, initrd string) base.Factory 
 	return &templateFactory{s: s}
 }
 
-func NewFromExisted(s *template.TemplateVmState) base.Factory {
+func NewFromExisted(s *template.TemplateVmConfig) base.Factory {
 	return &templateFactory{s: s}
 }
 

--- a/hypervisor/driver.go
+++ b/hypervisor/driver.go
@@ -39,6 +39,7 @@ type GuestNicInfo struct {
 }
 
 type HypervisorDriver interface {
+	Name() string
 	InitContext(homeDir string) DriverContext
 
 	LoadContext(persisted map[string]interface{}) (DriverContext, error)
@@ -97,6 +98,10 @@ type EmptyContext struct{}
 
 func (ed *EmptyDriver) Initialize() error {
 	return nil
+}
+
+func (ed *EmptyDriver) Name() string {
+	return "empty"
 }
 
 func (ed *EmptyDriver) InitContext(homeDir string) DriverContext {

--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -45,6 +45,10 @@ func InitDriver() *LibvirtDriver {
 	}
 }
 
+func (ld *LibvirtDriver) Name() string {
+	return "libvirt"
+}
+
 func (ld *LibvirtDriver) InitContext(homeDir string) hypervisor.DriverContext {
 	return &LibvirtContext{
 		driver: ld,

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -46,6 +46,10 @@ func InitDriver() *QemuDriver {
 	}
 }
 
+func (qd *QemuDriver) Name() string {
+	return "qemu"
+}
+
 func (qd *QemuDriver) InitContext(homeDir string) hypervisor.DriverContext {
 	if _, err := os.Stat(QemuLogDir); os.IsNotExist(err) {
 		os.Mkdir(QemuLogDir, 0755)

--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -42,6 +42,10 @@ func InitDriver() *VBoxDriver {
 	return vd
 }
 
+func (vd *VBoxDriver) Name() string {
+	return "vbox"
+}
+
 func (vd *VBoxDriver) InitContext(homeDir string) hypervisor.DriverContext {
 	return &VBoxContext{
 		Driver:  vd,

--- a/hypervisor/xen/xen.go
+++ b/hypervisor/xen/xen.go
@@ -109,6 +109,9 @@ func InitDriver() *XenDriver {
 }
 
 //judge if the xl is available and if the version and cap is acceptable
+func (xd *XenDriver) Name() string {
+	return "xen"
+}
 
 func (xd *XenDriver) InitContext(homeDir string) hypervisor.DriverContext {
 	return &XenContext{

--- a/main.go
+++ b/main.go
@@ -94,6 +94,10 @@ func main() {
 			Usage: "runv-compatible initrd for the container",
 		},
 		cli.StringFlag{
+			Name:  "template",
+			Usage: "path to the template vm state directory",
+		},
+		cli.StringFlag{
 			Name:  "vbox",
 			Usage: "runv-compatible boot ISO for the container for vbox driver",
 		},

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/codegangsta/cli"
@@ -84,7 +83,6 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "driver",
-			Value: getDefaultDriver(),
 			Usage: "hypervisor driver (supports: kvm xen vbox)",
 		},
 		cli.StringFlag{
@@ -112,16 +110,6 @@ func main() {
 	if err := app.Run(os.Args); err != nil {
 		fmt.Printf("%s\n", err.Error())
 	}
-}
-
-func getDefaultDriver() string {
-	if runtime.GOOS == "linux" {
-		return "qemu"
-	}
-	if runtime.GOOS == "darwin" {
-		return "vbox"
-	}
-	return ""
 }
 
 func getClient(address string) types.APIClient {

--- a/template/template.go
+++ b/template/template.go
@@ -22,6 +22,7 @@ import (
 
 type TemplateVmConfig struct {
 	StatePath string `json:"statepath"`
+	Driver    string `json:"driver"`
 	Cpu       int    `json:"cpu"`
 	Memory    int    `json:"memory"`
 	Kernel    string `json:"kernel"`
@@ -85,7 +86,16 @@ func CreateTemplateVM(statePath, vmName string, cpu, mem int, kernel, initrd str
 	// so we wait here. We should fix it in the qemu driver side.
 	time.Sleep(1 * time.Second)
 
-	return &TemplateVmConfig{StatePath: statePath, Cpu: cpu, Memory: mem, Kernel: kernel, Initrd: initrd}, nil
+	config := &TemplateVmConfig{
+		StatePath: statePath,
+		Driver:    hypervisor.HDriver.Name(),
+		Cpu:       cpu,
+		Memory:    mem,
+		Kernel:    kernel,
+		Initrd:    initrd,
+	}
+
+	return config, nil
 }
 
 func (t *TemplateVmConfig) BootConfigFromTemplate() *hypervisor.BootConfig {

--- a/template/template.go
+++ b/template/template.go
@@ -1,8 +1,11 @@
 package template
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -93,6 +96,18 @@ func CreateTemplateVM(statePath, vmName string, cpu, mem int, kernel, initrd str
 		Memory:    mem,
 		Kernel:    kernel,
 		Initrd:    initrd,
+	}
+
+	configData, err := json.MarshalIndent(config, "", "\t")
+	if err != nil {
+		glog.V(1).Infof("%s\n", err.Error())
+		return nil, err
+	}
+	configFile := filepath.Join(statePath, "config.json")
+	err = ioutil.WriteFile(configFile, configData, 0644)
+	if err != nil {
+		glog.V(1).Infof("%s\n", err.Error())
+		return nil, err
 	}
 
 	return config, nil

--- a/template/template.go
+++ b/template/template.go
@@ -20,7 +20,7 @@ import (
 //
 // Phoenix rising from the ashes
 
-type TemplateVmState struct {
+type TemplateVmConfig struct {
 	StatePath string `json:"statepath"`
 	Cpu       int    `json:"cpu"`
 	Memory    int    `json:"memory"`
@@ -28,10 +28,10 @@ type TemplateVmState struct {
 	Initrd    string `json:"initrd"`
 }
 
-func CreateTemplateVM(statePath, vmName string, cpu, mem int, kernel, initrd string) (t *TemplateVmState, err error) {
+func CreateTemplateVM(statePath, vmName string, cpu, mem int, kernel, initrd string) (t *TemplateVmConfig, err error) {
 	defer func() {
 		if err != nil {
-			(&TemplateVmState{StatePath: statePath}).Destroy()
+			(&TemplateVmConfig{StatePath: statePath}).Destroy()
 		}
 	}()
 
@@ -85,10 +85,10 @@ func CreateTemplateVM(statePath, vmName string, cpu, mem int, kernel, initrd str
 	// so we wait here. We should fix it in the qemu driver side.
 	time.Sleep(1 * time.Second)
 
-	return &TemplateVmState{StatePath: statePath, Cpu: cpu, Memory: mem, Kernel: kernel, Initrd: initrd}, nil
+	return &TemplateVmConfig{StatePath: statePath, Cpu: cpu, Memory: mem, Kernel: kernel, Initrd: initrd}, nil
 }
 
-func (t *TemplateVmState) BootConfigFromTemplate() *hypervisor.BootConfig {
+func (t *TemplateVmConfig) BootConfigFromTemplate() *hypervisor.BootConfig {
 	return &hypervisor.BootConfig{
 		CPU:              t.Cpu,
 		Memory:           t.Memory,
@@ -103,11 +103,11 @@ func (t *TemplateVmState) BootConfigFromTemplate() *hypervisor.BootConfig {
 }
 
 // boot vm from template, the returned vm is paused
-func (t *TemplateVmState) NewVmFromTemplate(vmName string) (*hypervisor.Vm, error) {
+func (t *TemplateVmConfig) NewVmFromTemplate(vmName string) (*hypervisor.Vm, error) {
 	return hypervisor.GetVm(vmName, t.BootConfigFromTemplate(), true, false)
 }
 
-func (t *TemplateVmState) Destroy() {
+func (t *TemplateVmConfig) Destroy() {
 	for i := 0; i < 5; i++ {
 		err := syscall.Unmount(t.StatePath, 0)
 		if err != nil {

--- a/template/template.go
+++ b/template/template.go
@@ -16,7 +16,7 @@ import (
 // is StatePath/state
 //
 // New Vm can be booted from the saved TemplateVm states with all the initial
-// memory is shared(copy-on-write) with the TemplateVm(templatePath/vmName/memory)
+// memory is shared(copy-on-write) with the TemplateVm(statePath/memory)
 //
 // Phoenix rising from the ashes
 
@@ -28,8 +28,7 @@ type TemplateVmState struct {
 	Initrd    string `json:"initrd"`
 }
 
-func CreateTemplateVM(templatePath, vmName string, cpu, mem int, kernel, initrd string) (t *TemplateVmState, err error) {
-	statePath := templatePath + "/" + vmName
+func CreateTemplateVM(statePath, vmName string, cpu, mem int, kernel, initrd string) (t *TemplateVmState, err error) {
 	defer func() {
 		if err != nil {
 			(&TemplateVmState{StatePath: statePath}).Destroy()


### PR DESCRIPTION
The feature vm-template makes the containers(VMs) can
be started in 130ms and save 80M memory for every
container(VM). So that the hyper/runv containers are fast
and high-density as normal containers.