### PR TITLE
fix travis tests to work in forked repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - cd ${TRAVIS_BUILD_DIR}
   - hack/verify-gofmt.sh
   - hack/validate-vet.sh
+  - test -d $GOPATH/src/github.com/hyperhq/runv || ln -s ${TRAVIS_BUILD_DIR} $GOPATH/src/github.com/hyperhq/runv
   - ./autogen.sh && ./configure && make && sudo GOPATH=${GOPATH} PATH=${PATH} GOROOT=${GOROOT} make install
 
 script:


### PR DESCRIPTION
Travis test fails when running out of forked repositories where TRAVIS_BUILD_DIR is not 
$HOME/gopath/src/github.com/hyperhq/runv
but something like
$HOME/gopath/src/github.com/pmorjan/runv

```
main.go:14:2: cannot find package "github.com/hyperhq/runv/containerd" in any of:
	/home/travis/.gimme/versions/go1.4.linux.amd64/src/github.com/hyperhq/runv/containerd (from $GOROOT)
	/home/travis/gopath/src/github.com/pmorjan/runv/Godeps/_workspace/src/github.com/hyperhq/runv/containerd (from $GOPATH)
```
This simple patch creates a symbolic link for .../hyperhq/runv if necessary.

Signed-off-by: Peter Morjan <peter.morjan@de.ibm.com>