### PR TITLE
fix travis tests to work in forked repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 dist: trusty
 
 language: go
+go_import_path: github.com/hyperhq/runv
 
 matrix:
   include:


### PR DESCRIPTION
Travis test fails when running out of forked repositories where TRAVIS_BUILD_DIR is not 
$HOME/gopath/src/github.com/hyperhq/runv
but something like
$HOME/gopath/src/github.com/pmorjan/runv

```
main.go:14:2: cannot find package "github.com/hyperhq/runv/containerd" in any of:
	/home/travis/.gimme/versions/go1.4.linux.amd64/src/github.com/hyperhq/runv/containerd (from $GOROOT)
	/home/travis/gopath/src/github.com/pmorjan/runv/Godeps/_workspace/src/github.com/hyperhq/runv/containerd (from $GOPATH)
```
This patch uses 'go_import_path' to place the runv module into the correct location.
Thanks to @feiskyer for the hint.