### PR TITLE
add multiarch support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 dist: trusty
 
 language: go
+go_import_path: github.com/hyperhq/runv
 
 matrix:
   include:

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -33,17 +32,6 @@ type QemuContext struct {
 
 func qemuContext(ctx *hypervisor.VmContext) *QemuContext {
 	return ctx.DCtx.(*QemuContext)
-}
-
-func InitDriver() *QemuDriver {
-	cmd, err := exec.LookPath("qemu-system-x86_64")
-	if err != nil {
-		return nil
-	}
-
-	return &QemuDriver{
-		executable: cmd,
-	}
 }
 
 func (qd *QemuDriver) Name() string {
@@ -338,81 +326,4 @@ func (qc *QemuContext) Save(ctx *hypervisor.VmContext, path string, result chan<
 
 func (qc *QemuDriver) SupportLazyMode() bool {
 	return false
-}
-
-func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
-	if ctx.Boot == nil {
-		ctx.Boot = &hypervisor.BootConfig{
-			CPU:    1,
-			Memory: 128,
-			Kernel: hypervisor.DefaultKernel,
-			Initrd: hypervisor.DefaultInitrd,
-		}
-	}
-	boot := ctx.Boot
-	qc.cpus = boot.CPU
-
-	var machineClass, memParams, cpuParams string
-	if boot.HotAddCpuMem || boot.BootToBeTemplate || boot.BootFromTemplate {
-		machineClass = "pc-i440fx-2.1"
-		memParams = fmt.Sprintf("size=%d,slots=1,maxmem=%dM", boot.Memory, hypervisor.DefaultMaxMem) // TODO set maxmem to the total memory of the system
-		cpuParams = fmt.Sprintf("cpus=%d,maxcpus=%d", boot.CPU, hypervisor.DefaultMaxCpus)           // TODO set it to the cpus of the system
-	} else {
-		machineClass = "pc-i440fx-2.0"
-		memParams = strconv.Itoa(boot.Memory)
-		cpuParams = strconv.Itoa(boot.CPU)
-	}
-
-	params := []string{
-		"-machine", machineClass + ",accel=kvm,usb=off", "-global", "kvm-pit.lost_tick_policy=discard", "-cpu", "host"}
-	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
-		glog.V(1).Info("kvm not exist change to no kvm mode")
-		params = []string{"-machine", machineClass + ",usb=off", "-cpu", "core2duo"}
-	}
-
-	if boot.Bios != "" && boot.Cbfs != "" {
-		params = append(params,
-			"-drive", fmt.Sprintf("if=pflash,file=%s,readonly=on", boot.Bios),
-			"-drive", fmt.Sprintf("if=pflash,file=%s,readonly=on", boot.Cbfs))
-	} else if boot.Bios != "" {
-		params = append(params,
-			"-bios", boot.Bios,
-			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyS0 panic=1 no_timer_check")
-	} else if boot.Cbfs != "" {
-		params = append(params,
-			"-drive", fmt.Sprintf("if=pflash,file=%s,readonly=on", boot.Cbfs))
-	} else {
-		params = append(params,
-			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyS0 panic=1 no_timer_check")
-	}
-
-	params = append(params,
-		"-realtime", "mlock=off", "-no-user-config", "-nodefaults", "-no-hpet",
-		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
-		"-m", memParams, "-smp", cpuParams)
-
-	if boot.BootToBeTemplate || boot.BootFromTemplate {
-		memObject := fmt.Sprintf("memory-backend-file,id=hyper-template-memory,size=%dM,mem-path=%s", boot.Memory, boot.MemoryPath)
-		if boot.BootToBeTemplate {
-			memObject = memObject + ",share=on"
-		}
-		nodeConfig := fmt.Sprintf("node,nodeid=0,cpus=0-%d,memdev=hyper-template-memory", hypervisor.DefaultMaxCpus-1)
-		params = append(params, "-object", memObject, "-numa", nodeConfig)
-		if boot.BootFromTemplate {
-			params = append(params, "-S", "-incoming", fmt.Sprintf("exec:cat %s", boot.DevicesStatePath))
-		}
-	} else if boot.HotAddCpuMem {
-		nodeConfig := fmt.Sprintf("node,nodeid=0,cpus=0-%d,mem=%d", hypervisor.DefaultMaxCpus-1, boot.Memory)
-		params = append(params, "-numa", nodeConfig)
-	}
-
-	return append(params, "-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName), "-serial", fmt.Sprintf("unix:%s,server,nowait", ctx.ConsoleSockName),
-		"-device", "virtio-serial-pci,id=virtio-serial0,bus=pci.0,addr=0x2", "-device", "virtio-scsi-pci,id=scsi0,bus=pci.0,addr=0x3",
-		"-chardev", fmt.Sprintf("socket,id=charch0,path=%s,server,nowait", ctx.HyperSockName),
-		"-device", "virtserialport,bus=virtio-serial0.0,nr=1,chardev=charch0,id=channel0,name=sh.hyper.channel.0",
-		"-chardev", fmt.Sprintf("socket,id=charch1,path=%s,server,nowait", ctx.TtySockName),
-		"-device", "virtserialport,bus=virtio-serial0.0,nr=2,chardev=charch1,id=channel1,name=sh.hyper.channel.1",
-		"-fsdev", fmt.Sprintf("local,id=virtio9p,path=%s,security_model=none", ctx.ShareDir),
-		"-device", fmt.Sprintf("virtio-9p-pci,fsdev=virtio9p,mount_tag=%s", hypervisor.ShareDirTag),
-	)
 }

--- a/hypervisor/qemu/qemu_amd64.go
+++ b/hypervisor/qemu/qemu_amd64.go
@@ -1,0 +1,101 @@
+// +build linux,amd64
+
+package qemu
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/hyperhq/runv/hypervisor"
+)
+
+func InitDriver() *QemuDriver {
+	cmd, err := exec.LookPath("qemu-system-x86_64")
+	if err != nil {
+		return nil
+	}
+
+	return &QemuDriver{
+		executable: cmd,
+	}
+}
+
+func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
+	if ctx.Boot == nil {
+		ctx.Boot = &hypervisor.BootConfig{
+			CPU:    1,
+			Memory: 128,
+			Kernel: hypervisor.DefaultKernel,
+			Initrd: hypervisor.DefaultInitrd,
+		}
+	}
+	boot := ctx.Boot
+	qc.cpus = boot.CPU
+
+	var machineClass, memParams, cpuParams string
+	if boot.HotAddCpuMem || boot.BootToBeTemplate || boot.BootFromTemplate {
+		machineClass = "pc-i440fx-2.1"
+		memParams = fmt.Sprintf("size=%d,slots=1,maxmem=%dM", boot.Memory, hypervisor.DefaultMaxMem) // TODO set maxmem to the total memory of the system
+		cpuParams = fmt.Sprintf("cpus=%d,maxcpus=%d", boot.CPU, hypervisor.DefaultMaxCpus)           // TODO set it to the cpus of the system
+	} else {
+		machineClass = "pc-i440fx-2.0"
+		memParams = strconv.Itoa(boot.Memory)
+		cpuParams = strconv.Itoa(boot.CPU)
+	}
+
+	params := []string{
+		"-machine", machineClass + ",accel=kvm,usb=off", "-global", "kvm-pit.lost_tick_policy=discard", "-cpu", "host"}
+	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
+		glog.V(1).Info("kvm not exist change to no kvm mode")
+		params = []string{"-machine", machineClass + ",usb=off", "-cpu", "core2duo"}
+	}
+
+	if boot.Bios != "" && boot.Cbfs != "" {
+		params = append(params,
+			"-drive", fmt.Sprintf("if=pflash,file=%s,readonly=on", boot.Bios),
+			"-drive", fmt.Sprintf("if=pflash,file=%s,readonly=on", boot.Cbfs))
+	} else if boot.Bios != "" {
+		params = append(params,
+			"-bios", boot.Bios,
+			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyS0 panic=1 no_timer_check")
+	} else if boot.Cbfs != "" {
+		params = append(params,
+			"-drive", fmt.Sprintf("if=pflash,file=%s,readonly=on", boot.Cbfs))
+	} else {
+		params = append(params,
+			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyS0 panic=1 no_timer_check")
+	}
+
+	params = append(params,
+		"-realtime", "mlock=off", "-no-user-config", "-nodefaults", "-no-hpet",
+		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-m", memParams, "-smp", cpuParams)
+
+	if boot.BootToBeTemplate || boot.BootFromTemplate {
+		memObject := fmt.Sprintf("memory-backend-file,id=hyper-template-memory,size=%dM,mem-path=%s", boot.Memory, boot.MemoryPath)
+		if boot.BootToBeTemplate {
+			memObject = memObject + ",share=on"
+		}
+		nodeConfig := fmt.Sprintf("node,nodeid=0,cpus=0-%d,memdev=hyper-template-memory", hypervisor.DefaultMaxCpus-1)
+		params = append(params, "-object", memObject, "-numa", nodeConfig)
+		if boot.BootFromTemplate {
+			params = append(params, "-S", "-incoming", fmt.Sprintf("exec:cat %s", boot.DevicesStatePath))
+		}
+	} else if boot.HotAddCpuMem {
+		nodeConfig := fmt.Sprintf("node,nodeid=0,cpus=0-%d,mem=%d", hypervisor.DefaultMaxCpus-1, boot.Memory)
+		params = append(params, "-numa", nodeConfig)
+	}
+
+	return append(params, "-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName), "-serial", fmt.Sprintf("unix:%s,server,nowait", ctx.ConsoleSockName),
+		"-device", "virtio-serial-pci,id=virtio-serial0,bus=pci.0,addr=0x2", "-device", "virtio-scsi-pci,id=scsi0,bus=pci.0,addr=0x3",
+		"-chardev", fmt.Sprintf("socket,id=charch0,path=%s,server,nowait", ctx.HyperSockName),
+		"-device", "virtserialport,bus=virtio-serial0.0,nr=1,chardev=charch0,id=channel0,name=sh.hyper.channel.0",
+		"-chardev", fmt.Sprintf("socket,id=charch1,path=%s,server,nowait", ctx.TtySockName),
+		"-device", "virtserialport,bus=virtio-serial0.0,nr=2,chardev=charch1,id=channel1,name=sh.hyper.channel.1",
+		"-fsdev", fmt.Sprintf("local,id=virtio9p,path=%s,security_model=none", ctx.ShareDir),
+		"-device", fmt.Sprintf("virtio-9p-pci,fsdev=virtio9p,mount_tag=%s", hypervisor.ShareDirTag),
+	)
+}

--- a/hypervisor/qemu/qemu_ppc64le.go
+++ b/hypervisor/qemu/qemu_ppc64le.go
@@ -1,0 +1,63 @@
+// +build linux,ppc64le
+
+package qemu
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+
+	"github.com/hyperhq/runv/hypervisor"
+)
+
+func InitDriver() *QemuDriver {
+	cmd, err := exec.LookPath("qemu-system-ppc64le")
+	if err != nil {
+		return nil
+	}
+
+	return &QemuDriver{
+		executable: cmd,
+	}
+}
+
+func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
+	if ctx.Boot == nil {
+		ctx.Boot = &hypervisor.BootConfig{
+			CPU:    1,
+			Memory: 256, // The minimum requirement for running a VM on PowerPC LE arch is 256M
+			Kernel: hypervisor.DefaultKernel,
+			Initrd: hypervisor.DefaultInitrd,
+		}
+	}
+	boot := ctx.Boot
+	qc.cpus = boot.CPU
+
+	var memParams, cpuParams string
+	if ctx.Boot.HotAddCpuMem {
+		memParams = fmt.Sprintf("size=%d,slots=1,maxmem=%dM", ctx.Boot.Memory, hypervisor.DefaultMaxMem) // TODO set maxmem to the total memory of the system
+		cpuParams = fmt.Sprintf("cpus=%d,maxcpus=%d", ctx.Boot.CPU, hypervisor.DefaultMaxCpus)           // TODO set it to the cpus of the system
+	} else {
+		memParams = strconv.Itoa(ctx.Boot.Memory)
+		cpuParams = strconv.Itoa(ctx.Boot.CPU)
+	}
+	memParams = "256"
+	cpuParams = "1"
+
+	return []string{
+		"-machine", "pseries,accel=kvm,usb=off", "-global", "kvm-pit.lost_tick_policy=discard", "-cpu", "host",
+		"-kernel", boot.Kernel, "-initrd", boot.Initrd,
+		"-machine", "pseries,accel=kvm,usb=off", "-cpu", "host",
+		"-realtime", "mlock=off", "-no-user-config", "-nodefaults",
+		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-m", memParams, "-smp", cpuParams,
+		"-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName), "-serial", fmt.Sprintf("unix:%s,server,nowait", ctx.ConsoleSockName),
+		"-device", "virtio-serial-pci,id=virtio-serial0,bus=pci.0,addr=0x2", "-device", "virtio-scsi-pci,id=scsi0,bus=pci.0,addr=0x3",
+		"-chardev", fmt.Sprintf("socket,id=charch0,path=%s,server,nowait", ctx.HyperSockName),
+		"-device", "virtserialport,bus=virtio-serial0.0,nr=1,chardev=charch0,id=channel0,name=sh.hyper.channel.0",
+		"-chardev", fmt.Sprintf("socket,id=charch1,path=%s,server,nowait", ctx.TtySockName),
+		"-device", "virtserialport,bus=virtio-serial0.0,nr=2,chardev=charch1,id=channel1,name=sh.hyper.channel.1",
+		"-fsdev", fmt.Sprintf("local,id=virtio9p,path=%s,security_model=none", ctx.ShareDir),
+		"-device", fmt.Sprintf("virtio-9p-pci,fsdev=virtio9p,mount_tag=%s", hypervisor.ShareDirTag),
+	}
+}

--- a/hypervisor/qemu/qemu_s390x.go
+++ b/hypervisor/qemu/qemu_s390x.go
@@ -1,0 +1,65 @@
+// +build linux,s390x
+
+package qemu
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+
+	"github.com/hyperhq/runv/hypervisor"
+)
+
+func InitDriver() *QemuDriver {
+	cmd, err := exec.LookPath("qemu-system-s390x")
+	if err != nil {
+		return nil
+	}
+
+	return &QemuDriver{
+		executable: cmd,
+	}
+}
+
+func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
+	if ctx.Boot == nil {
+		ctx.Boot = &hypervisor.BootConfig{
+			CPU:    1,
+			Memory: 128,
+			Kernel: hypervisor.DefaultKernel,
+			Initrd: hypervisor.DefaultInitrd,
+		}
+	}
+	boot := ctx.Boot
+	qc.cpus = boot.CPU
+
+	var memParams, cpuParams string
+	if ctx.Boot.HotAddCpuMem {
+		memParams = fmt.Sprintf("size=%d,slots=1,maxmem=%dM", ctx.Boot.Memory, hypervisor.DefaultMaxMem) // TODO set maxmem to the total memory of the system
+		cpuParams = fmt.Sprintf("cpus=%d,maxcpus=%d", ctx.Boot.CPU, hypervisor.DefaultMaxCpus)           // TODO set it to the cpus of the system
+	} else {
+		memParams = strconv.Itoa(ctx.Boot.Memory)
+		cpuParams = strconv.Itoa(ctx.Boot.CPU)
+	}
+
+	return []string{
+		"-machine", "s390-ccw-virtio,accel=kvm,usb=off", "-cpu", "host",
+		"-kernel", boot.Kernel, "-initrd", boot.Initrd,
+		"-append", "\"console=ttyS1 panic=1 no_timer_check\"",
+		"-realtime", "mlock=off", "-no-user-config", "-nodefaults", "-enable-kvm",
+		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-m", memParams, "-smp", cpuParams,
+		"-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName),
+		"-chardev", fmt.Sprintf("socket,id=charconsole0,path=%s,server,nowait", ctx.ConsoleSockName),
+		"-device", "sclpconsole,chardev=charconsole0",
+		"-device", "virtio-serial-ccw,id=virtio-serial0",
+		"-device", "virtio-scsi-ccw,id=scsi0",
+		"-chardev", fmt.Sprintf("socket,id=charch0,path=%s,server,nowait", ctx.HyperSockName),
+		"-device", "virtserialport,bus=virtio-serial0.0,nr=1,chardev=charch0,id=channel0,name=sh.hyper.channel.0",
+		"-chardev", fmt.Sprintf("socket,id=charch1,path=%s,server,nowait", ctx.TtySockName),
+		"-device", "virtserialport,bus=virtio-serial0.0,nr=2,chardev=charch1,id=channel1,name=sh.hyper.channel.1",
+		"-fsdev", fmt.Sprintf("local,id=virtio9p,path=%s,security_model=none", ctx.ShareDir),
+		"-device", fmt.Sprintf("virtio-9p-ccw,fsdev=virtio9p,mount_tag=%s", hypervisor.ShareDirTag),
+	}
+
+}

--- a/hypervisor/qemu/qmp_wrapper.go
+++ b/hypervisor/qemu/qmp_wrapper.go
@@ -3,9 +3,7 @@ package qemu
 import (
 	"fmt"
 	"strconv"
-	"syscall"
 
-	"github.com/golang/glog"
 	"github.com/hyperhq/runv/hypervisor"
 	"github.com/hyperhq/runv/lib/utils"
 )
@@ -80,46 +78,6 @@ func newDiskDelSession(ctx *hypervisor.VmContext, qc *QemuContext, id int, callb
 	qc.qmp <- &QmpSession{
 		commands: commands,
 		respond:  defaultRespond(ctx.Hub, callback),
-	}
-}
-
-func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd uint64, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
-	busAddr := fmt.Sprintf("0x%x", addr)
-	commands := make([]*QmpCommand, 3)
-	scm := syscall.UnixRights(int(fd))
-	glog.V(1).Infof("send net to qemu at %d", int(fd))
-	commands[0] = &QmpCommand{
-		Execute: "getfd",
-		Arguments: map[string]interface{}{
-			"fdname": "fd" + device,
-		},
-		Scm: scm,
-	}
-	commands[1] = &QmpCommand{
-		Execute: "netdev_add",
-		Arguments: map[string]interface{}{
-			"type": "tap", "id": device, "fd": "fd" + device,
-		},
-	}
-	commands[2] = &QmpCommand{
-		Execute: "device_add",
-		Arguments: map[string]interface{}{
-			"driver": "virtio-net-pci",
-			"netdev": device,
-			"mac":    mac,
-			"bus":    "pci.0",
-			"addr":   busAddr,
-			"id":     device,
-		},
-	}
-
-	qc.qmp <- &QmpSession{
-		commands: commands,
-		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
-			Index:      index,
-			DeviceName: device,
-			Address:    addr,
-		}),
 	}
 }
 

--- a/hypervisor/qemu/qmp_wrapper_amd64.go
+++ b/hypervisor/qemu/qmp_wrapper_amd64.go
@@ -1,0 +1,51 @@
+// +build linux,amd64
+
+package qemu
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/golang/glog"
+	"github.com/hyperhq/runv/hypervisor"
+)
+
+func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd uint64, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
+	busAddr := fmt.Sprintf("0x%x", addr)
+	commands := make([]*QmpCommand, 3)
+	scm := syscall.UnixRights(int(fd))
+	glog.V(1).Infof("send net to qemu at %d", int(fd))
+	commands[0] = &QmpCommand{
+		Execute: "getfd",
+		Arguments: map[string]interface{}{
+			"fdname": "fd" + device,
+		},
+		Scm: scm,
+	}
+	commands[1] = &QmpCommand{
+		Execute: "netdev_add",
+		Arguments: map[string]interface{}{
+			"type": "tap", "id": device, "fd": "fd" + device,
+		},
+	}
+	commands[2] = &QmpCommand{
+		Execute: "device_add",
+		Arguments: map[string]interface{}{
+			"driver": "virtio-net-pci",
+			"netdev": device,
+			"mac":    mac,
+			"bus":    "pci.0",
+			"addr":   busAddr,
+			"id":     device,
+		},
+	}
+
+	qc.qmp <- &QmpSession{
+		commands: commands,
+		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
+			Index:      index,
+			DeviceName: device,
+			Address:    addr,
+		}),
+	}
+}

--- a/hypervisor/qemu/qmp_wrapper_ppc64le.go
+++ b/hypervisor/qemu/qmp_wrapper_ppc64le.go
@@ -1,0 +1,51 @@
+// +build linux,ppc64le
+
+package qemu
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/golang/glog"
+	"github.com/hyperhq/runv/hypervisor"
+)
+
+func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd uint64, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
+	busAddr := fmt.Sprintf("0x%x", addr)
+	commands := make([]*QmpCommand, 3)
+	scm := syscall.UnixRights(int(fd))
+	glog.V(1).Infof("send net to qemu at %d", int(fd))
+	commands[0] = &QmpCommand{
+		Execute: "getfd",
+		Arguments: map[string]interface{}{
+			"fdname": "fd" + device,
+		},
+		Scm: scm,
+	}
+	commands[1] = &QmpCommand{
+		Execute: "netdev_add",
+		Arguments: map[string]interface{}{
+			"type": "tap", "id": device, "fd": "fd" + device,
+		},
+	}
+	commands[2] = &QmpCommand{
+		Execute: "device_add",
+		Arguments: map[string]interface{}{
+			"driver": "virtio-net-pci",
+			"netdev": device,
+			"mac":    mac,
+			"bus":    "pci.0",
+			"addr":   busAddr,
+			"id":     device,
+		},
+	}
+
+	qc.qmp <- &QmpSession{
+		commands: commands,
+		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
+			Index:      index,
+			DeviceName: device,
+			Address:    addr,
+		}),
+	}
+}

--- a/hypervisor/qemu/qmp_wrapper_s390x.go
+++ b/hypervisor/qemu/qmp_wrapper_s390x.go
@@ -1,0 +1,47 @@
+// +build linux,s390x
+
+package qemu
+
+import (
+	"syscall"
+
+	"github.com/golang/glog"
+	"github.com/hyperhq/runv/hypervisor"
+)
+
+func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd uint64, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
+	commands := make([]*QmpCommand, 3)
+	scm := syscall.UnixRights(int(fd))
+	glog.V(1).Infof("send net to qemu at %d", int(fd))
+	commands[0] = &QmpCommand{
+		Execute: "getfd",
+		Arguments: map[string]interface{}{
+			"fdname": "fd" + device,
+		},
+		Scm: scm,
+	}
+	commands[1] = &QmpCommand{
+		Execute: "netdev_add",
+		Arguments: map[string]interface{}{
+			"type": "tap", "id": device, "fd": "fd" + device,
+		},
+	}
+	commands[2] = &QmpCommand{
+		Execute: "device_add",
+		Arguments: map[string]interface{}{
+			"driver": "virtio-net-ccw",
+			"netdev": device,
+			"mac":    mac,
+			"id":     device,
+		},
+	}
+
+	qc.qmp <- &QmpSession{
+		commands: commands,
+		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
+			Index:      index,
+			DeviceName: device,
+			Address:    addr,
+		}),
+	}
+}


### PR DESCRIPTION
This patch adds initial support for s390x and ppc64le. The idea is to put all platform specific code into separated files for conditional compilation with the regular go build tool. 
Currently only a few functions related to qemu execution need to be adjusted. That's great.

This pr is mainly to explore options. We are getting good results on s390x running regular Docker container. ppc64le is also on it's way.
Thanks.
peter