### PR TITLE
POD support: Use ns-listerner pid as containers' pid

### DIFF
--- a/supervisor/hyperpod.go
+++ b/supervisor/hyperpod.go
@@ -390,7 +390,7 @@ func (hp *HyperPod) createContainer(container, bundlePath, stdin, stdout, stderr
 		Stdout: stdout,
 		Stderr: stderr,
 		Spec:   &spec.Process,
-		ProcId: -1,
+		ProcId: c.ownerPod.getNsPid(),
 
 		inerId:    inerProcessId,
 		ownerCont: c,


### PR DESCRIPTION
For the sake of K8S integration, we must have a mechanism to create a
pod and allow to integrate with CNI network plugins.

As CNI plugins are operating on nslistener namespaces, we should set pid
of nslistener as container's init pid, so that when we insert a NIC into
the "fake" namespace, the VM can get notifications.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>