### PR TITLE
Handle EOF in nsListenerStrap()

### DIFF
--- a/supervisor/hyperpod.go
+++ b/supervisor/hyperpod.go
@@ -3,6 +3,7 @@ package supervisor
 import (
 	"encoding/gob"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -209,6 +210,10 @@ func (hp *HyperPod) nsListenerStrap() {
 		update := NetlinkUpdate{}
 		err := listener.dec.Decode(&update)
 		if err != nil {
+			if err == io.EOF {
+				glog.Info("listener.dec.Decode NetlinkUpdate:", err)
+				break
+			}
 			glog.Error("listener.dec.Decode NetlinkUpdate error:", err)
 			continue
 		}


### PR DESCRIPTION
nsListenerStrap() has no possible exit for when the underlying socket is closed on it, leading to an endless loop on EOF. This commit adds an Info log and loop termination.

EDIT: This also seems to resolve #320 