### PR TITLE
make sure vm is shutdown before context is closed

### DIFF
--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -653,25 +653,23 @@ func (lc *LibvirtContext) Dump() (map[string]interface{}, error) {
 }
 
 func (lc *LibvirtContext) Shutdown(ctx *hypervisor.VmContext) {
-	go func() {
-		if lc.domain == nil {
-			ctx.Hub <- &hypervisor.VmExit{}
-			return
-		}
-		lc.domain.DestroyFlags(libvirtgo.VIR_DOMAIN_DESTROY_DEFAULT)
+	if lc.domain == nil {
 		ctx.Hub <- &hypervisor.VmExit{}
-	}()
+		return
+	}
+
+	lc.domain.DestroyFlags(libvirtgo.VIR_DOMAIN_DESTROY_DEFAULT)
+	ctx.Hub <- &hypervisor.VmExit{}
 }
 
 func (lc *LibvirtContext) Kill(ctx *hypervisor.VmContext) {
-	go func() {
-		if lc.domain == nil {
-			ctx.Hub <- &hypervisor.VmKilledEvent{Success: true}
-			return
-		}
-		lc.domain.DestroyFlags(libvirtgo.VIR_DOMAIN_DESTROY_DEFAULT)
+	if lc.domain == nil {
 		ctx.Hub <- &hypervisor.VmKilledEvent{Success: true}
-	}()
+		return
+	}
+
+	lc.domain.DestroyFlags(libvirtgo.VIR_DOMAIN_DESTROY_DEFAULT)
+	ctx.Hub <- &hypervisor.VmKilledEvent{Success: true}
 }
 
 func (lc *LibvirtContext) Close() {

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -317,7 +317,9 @@ func commonStateHandler(ctx *VmContext, ev VmEvent, hasPod bool) bool {
 		interruptEv := ev.(*Interrupted)
 		glog.Info("Connection interrupted: %s, quit...", interruptEv.Reason)
 		ctx.exitVM(true, fmt.Sprintf("connection to VM broken: %s", interruptEv.Reason), false, false)
-		ctx.onVmExit(hasPod)
+		if hasPod {
+			ctx.reclaimDevice()
+		}
 	case COMMAND_SHUTDOWN:
 		glog.Info("got shutdown command, shutting down")
 		ctx.exitVM(false, "", hasPod, ev.(*ShutdownCommand).Wait)


### PR DESCRIPTION
the Shutdown/Kill interface in libvirt driver is implemented
in goroutine, this may cause context is closed before Shutdown/Kill
is executed, the Close interface of libvirt will set domain to nil,
so the Shutdown/Kill won't shutdown libvirt domain indeed.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>