### PR TITLE
Add defaultCpu and defaultMemory to supervisor/createHyperpod.

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -114,7 +114,8 @@ var ContainerdCommand = cli.Command{
 		} else {
 			f = factory.NewFromConfigs(kernel, initrd, nil)
 		}
-		sv, err := supervisor.New(stateDir, containerdDir, f)
+		sv, err := supervisor.New(stateDir, containerdDir, f,
+			context.GlobalInt("default_cpus"), context.GlobalInt("default_memory"))
 		if err != nil {
 			glog.Infof("%v", err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -86,6 +86,16 @@ func main() {
 			Name:  "driver",
 			Usage: "hypervisor driver (supports: kvm xen vbox)",
 		},
+		cli.IntFlag{
+			Name:  "default_cpus",
+			Usage: "default number of vcpus to assign pod",
+			Value: 1,
+		},
+		cli.IntFlag{
+			Name:  "default_memory",
+			Usage: "default memory to assign pod (mb)",
+			Value: 128,
+		},
 		cli.StringFlag{
 			Name:  "kernel",
 			Usage: "kernel for the container",

--- a/start.go
+++ b/start.go
@@ -174,7 +174,12 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 				os.Exit(-1)
 			}
 
-			args := []string{"--kernel", kernel, "--initrd", initrd}
+			args := []string{
+				"--kernel", kernel,
+				"--initrd", initrd,
+				"--default_cpus", fmt.Sprintf("%d", context.GlobalInt("default_cpus")),
+				"--default_memory", fmt.Sprintf("%d", context.GlobalInt("default_memory")),
+			}
 			if context.GlobalBool("debug") {
 				args = append(args, "--debug")
 			}


### PR DESCRIPTION
Add the `--default_cpus` and `--default_memory` command line options so that the default VM pod-size in containerd mode can be specified, rather then defaulting to 1 cpu and 128mb of RAM.