### PR TITLE
launch containerd through "/proc/self/exe containerd"

### DIFF
--- a/start.go
+++ b/start.go
@@ -202,7 +202,7 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 				"--state-dir", root,
 				"--listen", filepath.Join(namespace, "namespaced.sock"),
 			)
-			cmd = exec.Command("runv", args...)
+			cmd = exec.Command("/proc/self/exe", args...)
 			cmd.Path = path
 			cmd.Dir = "/"
 			cmd.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
In cri-o, it use exec.Command(...) to launch runtime, it dosen't inherit PATH from parent process.
For runv, it can't launch containerd because  can't find  runv in PATH.
So use "/proc/self/exe" rather than "runv" to launch containerd.