### PR TITLE
Tiny fix to integrate with cri-o

### DIFF
--- a/start.go
+++ b/start.go
@@ -202,8 +202,10 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 				"--state-dir", root,
 				"--listen", filepath.Join(namespace, "namespaced.sock"),
 			)
-			cmd = exec.Command("runv", args...)
-			cmd.Path = path
+			cmd = &exec.Cmd{
+				Path: path,
+				Args: append([]string{"runv"}, args...),
+			}
 			cmd.Dir = "/"
 			cmd.SysProcAttr = &syscall.SysProcAttr{
 				Setsid: true,

--- a/supervisor/container.go
+++ b/supervisor/container.go
@@ -312,7 +312,7 @@ func mountToRootfs(m *specs.Mount, rootfs, mountLabel string) error {
 	}
 
 	switch m.Type {
-	case "proc", "sysfs", "mqueue", "tmpfs", "cgroup":
+	case "proc", "sysfs", "mqueue", "tmpfs", "cgroup", "devpts":
 		glog.V(3).Infof("Skip mount point %q of type %s", m.Destination, m.Type)
 		return nil
 	case "bind":


### PR DESCRIPTION
1. fix can't find runv when it is not in $PATH
2. do not support devpts mount type yet, skip it.

cc @laijs 