### PR TITLE
Fix setWindowSize not working with docker

### DIFF
--- a/supervisor/process.go
+++ b/supervisor/process.go
@@ -64,6 +64,10 @@ func (p *Process) setupIO() error {
 }
 
 func (p *Process) ttyResize(container string, width, height int) error {
+	// If working on the primary process, do not pass execId (it won't be recognized)
+	if p.inerId == fmt.Sprintf("%s-init", container) {
+		return p.ownerCont.ownerPod.vm.Tty(container, "", height, width)
+	}
 	return p.ownerCont.ownerPod.vm.Tty(container, p.inerId, height, width)
 }
 


### PR DESCRIPTION
Docker sets "execId" to containerId + "-init" when working from the command line
with `docker run`. This led to `runv` being unable to find the referred
TTY context when setWindowSize messages were received.

This patch adds a check for the "-init" suffix and causes executors matching
this form to drop through to looking for the containerId only, which allows
setWindowSize to function correctly.