### PR TITLE
fix readonly rootfs failed when creating necessary dirs

### DIFF
--- a/lib/utils/mount_linux.go
+++ b/lib/utils/mount_linux.go
@@ -5,16 +5,16 @@ import (
 	"syscall"
 )
 
-func Mount(src, dst string, readOnly bool) error {
+func Mount(src, dst string) error {
 	if _, err := os.Stat(dst); os.IsNotExist(err) {
 		os.MkdirAll(dst, 0755)
 	}
 
-	err := syscall.Mount(src, dst, "", syscall.MS_BIND|syscall.MS_REC, "")
-	if err == nil && readOnly {
-		err = syscall.Mount(src, dst, "", syscall.MS_BIND|syscall.MS_RDONLY|syscall.MS_REMOUNT|syscall.MS_REC, "")
-	}
-	return err
+	return syscall.Mount(src, dst, "", syscall.MS_BIND|syscall.MS_REC, "")
+}
+
+func SetReadonly(rootfs string) error {
+	return syscall.Mount(rootfs, rootfs, "", syscall.MS_BIND|syscall.MS_REMOUNT|syscall.MS_RDONLY|syscall.MS_REC, "")
 }
 
 func Umount(root string) {


### PR DESCRIPTION
Mainly fix readonly rootfs failed when creating necessary dirs

1. move mounting readonly rootfs to bottom
2. pre-create necessary dirs used in hyperstart

cc @laijs 

Signed-off-by: Crazykev <crazykev@zju.edu.cn>