### PR TITLE
Improve supervisor eventlog locking and API compliance.

### DIFF
--- a/containerd/api/grpc/server/server.go
+++ b/containerd/api/grpc/server/server.go
@@ -154,7 +154,7 @@ func (s *apiServer) Events(r *types.EventsRequest, stream types.API_EventsServer
 		}
 		t = from
 	}
-	events := s.sv.Events.Events(t)
+	events := s.sv.Events.Events(t, r.StoredOnly, r.Id)
 	defer s.sv.Events.Unsubscribe(events)
 	for e := range events {
 		tsp, err := ptypes.TimestampProto(e.Timestamp)

--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -163,7 +163,7 @@ func daemon(sv *supervisor.Supervisor, address string) error {
 }
 
 func namespaceShare(sv *supervisor.Supervisor, namespace, state string) {
-	events := sv.Events.Events(time.Time{})
+	events := sv.Events.Events(time.Time{}, false, "")
 	containerCount := 0
 	for e := range events {
 		if e.Type == supervisor.EventContainerStart {

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -116,7 +116,7 @@ func (sv *Supervisor) getProcess(container, processId string) *Process {
 }
 
 func (sv *Supervisor) reaper() {
-	events := sv.Events.Events(time.Time{})
+	events := sv.Events.Events(time.Time{}, false, "")
 	for e := range events {
 		if e.Type == EventExit {
 			go sv.reap(e.ID, e.PID)


### PR DESCRIPTION
Add finer-grained locking to the supervisor eventlog based on the upstream docker containerd code.

Adds full compliance for the Event() API by supporting queries for specific container IDs and stored events only, as required by newer Docker daemons in order to recover from hard shutdowns without deadlocking the docker daemon.

This fixes the problem of deadlocking docker when running with runv and doing a hard shutdown, as runv was not responding with the events docker actually wanted.

The code is mostly adapted from https://github.com/docker/containerd/blob/master/supervisor/supervisor.go.
