### PR TITLE
Handle exec being called before a container is initialized correctly.

### DIFF
--- a/supervisor/hyperpod.go
+++ b/supervisor/hyperpod.go
@@ -416,7 +416,9 @@ func (hp *HyperPod) createContainer(container, bundlePath, stdin, stdout, stderr
 	c.ownerPod.Containers[container] = c
 
 	glog.Infof("createContainer() calls c.run(p)")
-	c.run(p)
+	if err := c.run(p); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 


### PR DESCRIPTION
Running a command like the following:

```
cid=$(./docker run -tid busybox sh) && \
    echo $cid && ./docker exec -ti $cid echo hello
```

would block indefinitely because we would return success to docker, but fail because the exec is attempted before the container is started up.

This leads to the docker daemon blocking indefinitely waiting for an exec command it believes was successful via containerd.

This patch solves the problem by blocking the containerd responses until the VM startup has returned and moved to process wait (or else returning an error if it fails at this stage). This resolves deadlocks into docker and allows the above command to succeed.

Closes #279
