### PR TITLE
suppor nfs volume

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -11,6 +11,10 @@ func (v *VolumeDescription) IsDir() bool {
 	return v.Format == "vfs"
 }
 
+func (v *VolumeDescription) IsNas() bool {
+	return v.Format == "nas"
+}
+
 func SandboxInfoFromOCF(s *specs.Spec) *SandboxConfig {
 	return &SandboxConfig{
 		Hostname: s.Hostname,

--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -378,8 +378,8 @@ func (ctx *VmContext) AddVolume(vol *api.VolumeDescription, result chan api.Resu
 
 	dc := NewDiskContext(ctx, vol)
 
-	if vol.IsDir() {
-		ctx.Log(INFO, "return volume add success for dir %s", vol.Name)
+	if vol.IsDir() || vol.IsNas() {
+		ctx.Log(INFO, "return volume add success for dir/nas %s", vol.Name)
 		result <- api.NewResultBase(vol.Name, true, "")
 	} else {
 		ctx.Log(DEBUG, "insert disk for volume %s", vol.Name)


### PR DESCRIPTION
VolumeDescription.Source is `<server>:/<export>`, and
VolumeDescription.Format is `nas` and VolumeDescription.Fstype should be `nfs`. The volume is passed to hyperstart for further handling.

Works with hyperstart change (https://github.com/hyperhq/hyperstart/pull/252).

nfs volume podfile example:
```
{
  "resource": {
    "vcpu": 1,
    "memory": 1024
  },
  "containers": [{
      "image": "bergwolf/ubuntu-fio",
      "volumes": [{
        "volume": "sharevolume",
        "path": "/export",
        "readOnly": false
      }]
  }],
  "volumes": [{
    "name": "sharevolume",
    "source": "192.168.80.72:/home/bergwolf",
    "format": "nas",
    "fstype": "nfs"
  }]
}
```

Test results:
```
[hypervsock@~]$sudo hyperctl run -d -p ubuntu.pod
POD id is pod-VVnZwkkoZp
Time to run a POD is 7733 ms
[hypervsock@~]$sudo hyperctl exec -t pod-VVnZwkkoZp bash
root@pod-VVnZwkkoZp:/# df
Filesystem                   1K-blocks      Used Available Use% Mounted on
/dev/sda                     104805376    298180 104507196   1% /
devtmpfs                         23808         0     23808   0% /dev
tmpfs                            26940         0     26940   0% /dev/shm
rootfs                           23808     16044      7764  68% /lib/modules/4.4.28-hyper
192.168.80.72:/home/bergwolf 410056704 108126208 301930496  27% /export
```