### PR TITLE
Fix a race which caused containerd to stop responding.

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -132,6 +132,22 @@ func InitContext(id string, hub chan VmEvent, client chan *types.VmResponse, dc 
 	return ctx, nil
 }
 
+// SendVmEvent enqueues a VmEvent onto the context. Returns an error if there is
+// no handler associated with the context. VmEvent handling happens in a
+// separate goroutine, so this is thread-safe and asynchronous.
+func (ctx *VmContext) SendVmEvent(ev VmEvent) error {
+	ctx.lock.Lock()
+	defer ctx.lock.Unlock()
+
+	if ctx.handler == nil {
+		return fmt.Errorf("VmContext(%s): event handler already shutdown.", ctx.Id)
+	}
+
+	ctx.Hub <- ev
+
+	return nil
+}
+
 func (ctx *VmContext) setTimeout(seconds int) {
 	if ctx.timer != nil {
 		ctx.unsetTimeout()

--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -23,6 +23,12 @@ func (ctx *VmContext) loop() {
 		glog.V(1).Infof("vm %s: main event loop got message %d(%s)", ctx.Id, ev.Event(), EventString(ev.Event()))
 		ctx.handler(ctx, ev)
 	}
+
+	// Unless the ctx.Hub channel is drained, processes sending operations can
+	// be left hanging waiting for a response. Since the handler is already
+	// gone, we return a fail to all these requests.
+
+	glog.V(1).Infof("vm %s: main event loop exiting", ctx.Id)
 }
 
 func (ctx *VmContext) handlePAEs() {

--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -332,10 +332,7 @@ func (vm *Vm) Shutdown() api.Result {
 
 // TODO: should we provide a method to force kill vm
 func (vm *Vm) Kill() {
-	vm.GenericOperation("KillSandbox", func(ctx *VmContext, result chan<- error) {
-		ctx.poweroffVM(false, "API Kill Sandbox")
-		result <- nil
-	}, StateRunning, StateTerminating)
+	vm.ctx.poweroffVM(false, "vm.Kill()")
 }
 
 func (vm *Vm) WriteFile(container, target string, data []byte) error {
@@ -795,7 +792,6 @@ func GetVm(vmId string, b *BootConfig, waitStarted, lazy bool) (*Vm, error) {
 			glog.Error("VM never started")
 			return nil, false
 		}, -1); err != nil {
-
 			vm.Kill()
 		}
 	}

--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -29,7 +29,6 @@ type Vm struct {
 	Mem  int
 	Lazy bool
 
-	Hub     chan VmEvent
 	clients *Fanout
 }
 
@@ -67,7 +66,6 @@ func (vm *Vm) Launch(b *BootConfig) (err error) {
 	ctx.Launch()
 	vm.ctx = ctx
 
-	vm.Hub = vmEvent
 	vm.clients = CreateFanout(Status, 128, false)
 
 	return nil
@@ -90,7 +88,6 @@ func (vm *Vm) AssociateVm(data []byte) error {
 
 	//	go vm.handlePodEvent(mypod)
 	//
-	vm.Hub = PodEvent
 	vm.clients = CreateFanout(Status, 128, false)
 
 	//	mypod.Status = types.S_POD_RUNNING
@@ -155,7 +152,15 @@ func (vm *Vm) ReleaseVm() error {
 	}, -1)
 
 	releasePodEvent := &ReleaseVMCommand{}
-	vm.Hub <- releasePodEvent
+
+	if vm.ctx == nil {
+		return fmt.Errorf("ReleaseVm(%s) failed: VmContext is nil", vm.Id)
+	}
+
+	if err := vm.ctx.SendVmEvent(releasePodEvent); err != nil {
+		return err
+	}
+
 	return <-result
 }
 
@@ -311,7 +316,14 @@ func (vm *Vm) Shutdown() api.Result {
 		return nil, false
 	}, -1)
 
-	vm.Hub <- &ShutdownCommand{}
+	if vm.ctx == nil {
+		return api.NewResultBase(vm.Id, false, "internal error - context == nil")
+	}
+
+	if err := vm.ctx.SendVmEvent(&ShutdownCommand{}); err != nil {
+		return api.NewResultBase(vm.Id, false, "vm context already exited")
+	}
+
 	if err := <-result; err != nil {
 		return api.NewResultBase(vm.Id, false, err.Error())
 	}
@@ -332,7 +344,6 @@ func (vm *Vm) WriteFile(container, target string, data []byte) error {
 
 func (vm *Vm) ReadFile(container, target string) ([]byte, error) {
 	return vm.ctx.hyperstart.ReadFile(container, target)
-
 }
 
 func (vm *Vm) SignalProcess(container, process string, signal syscall.Signal) error {
@@ -350,7 +361,7 @@ func (vm *Vm) AddRoute() error {
 
 func (vm *Vm) AddNic(info *api.InterfaceDescription) error {
 	client := make(chan api.Result, 1)
-	vm.SendGenericOperation("CreateInterface", func(ctx *VmContext, result chan<- error) {
+	vm.sendGenericOperation("CreateInterface", func(ctx *VmContext, result chan<- error) {
 		go ctx.AddInterface(info, client)
 	}, StateRunning)
 
@@ -371,7 +382,7 @@ func (vm *Vm) AddNic(info *api.InterfaceDescription) error {
 
 func (vm *Vm) DeleteNic(id string) error {
 	client := make(chan api.Result, 1)
-	vm.SendGenericOperation("NetDevRemovedEvent", func(ctx *VmContext, result chan<- error) {
+	vm.sendGenericOperation("NetDevRemovedEvent", func(ctx *VmContext, result chan<- error) {
 		ctx.RemoveInterface(id, client)
 	}, StateRunning)
 
@@ -703,20 +714,37 @@ func (vm *Vm) GetIPAddrs() []string {
 	return ips
 }
 
-func (vm *Vm) SendGenericOperation(name string, op func(ctx *VmContext, result chan<- error), states ...string) <-chan error {
+// sendGenericOperation queues a generic operation onto the VM's context if it
+// is in position to handle it.
+func (vm *Vm) sendGenericOperation(name string, op func(ctx *VmContext, result chan<- error), states ...string) <-chan error {
 	result := make(chan error, 1)
+
+	// Check vm context is available
+	if vm.ctx == nil {
+		result <- fmt.Errorf("sendGenericOperation(%s) failed: VmContext is nil", name)
+		return result
+	}
+
+	// Setup the generic operation
 	goe := &GenericOperation{
 		OpName: name,
 		State:  states,
 		OpFunc: op,
 		Result: result,
 	}
-	vm.Hub <- goe
+
+	// Try and send it - if we fail here, discard the channel and immediately
+	// push the failure state instead (goe isn't sent, so the result channel
+	// isn't used).
+	if err := vm.ctx.SendVmEvent(goe); err != nil {
+		result <- err
+	}
+
 	return result
 }
 
 func (vm *Vm) GenericOperation(name string, op func(ctx *VmContext, result chan<- error), states ...string) error {
-	return <-vm.SendGenericOperation(name, op, states...)
+	return <-vm.sendGenericOperation(name, op, states...)
 }
 
 func errorResponse(cause string) *types.VmResponse {
@@ -754,18 +782,24 @@ func GetVm(vmId string, b *BootConfig, waitStarted, lazy bool) (*Vm, error) {
 	}
 
 	if waitStarted {
+		glog.V(1).Info("waiting for vm to start")
 		if err := <-vm.WaitResponse(func(response *types.VmResponse) (error, bool) {
 			if response.Code == types.E_FAILED {
+				glog.Error("VM start failed")
 				return fmt.Errorf("vm start failed"), true
 			}
 			if response.Code == types.E_VM_RUNNING {
+				glog.V(1).Info("VM started successfully")
 				return nil, true
 			}
+			glog.Error("VM never started")
 			return nil, false
 		}, -1); err != nil {
+
 			vm.Kill()
 		}
 	}
 
+	glog.V(1).Info("GetVm succeeded (not waiting for startup)")
 	return vm, nil
 }


### PR DESCRIPTION
When a virtual machine error occurs leading to a VM shutdown, there is no
explicit denial of access to the `vm.Hub` channel used to send commands, but once
the `VmContext.loop()` function exited, nothing existed handling and cancelling
commands on that channel, nor notifying processes to stop writing to it.

This meant that runv could reliably trigger Docker/supervisord lock-ups when
a problem occurred with the VM startup while container commands were being
waited on (most commonly: `docker run <some image> sleep 10`, but having an
incorrect kernel configured in docker).

This commit fixes the problem by removing the duplication of channel logic
between `Vm` and `VmContext`. `Vm.SendGenericOperation` is made internal, and
calls to a wrapper function on `VmContext.SendVmEvent` to enqueue messages to
the context. This separation enables a check for an active event handler to be
performed before enqueuing a new message - and immediately returns an error if
the message cannot be queued allowing the caller to detect a situation where
the VM has died.

Closes #423.