### PR TITLE
add missing close(waitQmp)

### DIFF
--- a/hypervisor/qemu/qmp_handler.go
+++ b/hypervisor/qemu/qmp_handler.go
@@ -150,6 +150,8 @@ func qmpReceiver(qmp chan QmpInteraction, wait chan int, decoder *json.Decoder) 
 
 		if msg.MessageType() == QMP_EVENT && msg.(*QmpEvent).Type == QMP_EVENT_SHUTDOWN {
 			glog.V(0).Info("Shutdown, quit QMP receiver")
+			/* After shutdown, send wait notification to close qmp channel */
+			close(wait)
 			return
 		}
 	}


### PR DESCRIPTION
after vm shutdown, the goroutine was stalled on
qemu.(*QemuContext).Close(). fix it by adding missing close(waitQmp).

```
       0x9f47e4
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/qemu.(*QemuContext).Close+0x84
/root/work/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/qemu/qemu.go:181
       0x683650
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*VmContext).Close+0x130
/root/work/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/context.go:224
       0x695e93
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.stateRunning+0x1b3
/root/work/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/vm_states.go:227
       0x68819e
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*VmContext).loop+0x29e
/root/work/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/hypervisor.go:24
```

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>