### PR TITLE
avoid missing event

### DIFF
--- a/hypervisor/vm.go
+++ b/hypervisor/vm.go
@@ -106,20 +106,20 @@ func (vm *Vm) AssociateVm(data []byte) error {
 type matchResponse func(response *types.VmResponse) (error, bool)
 
 func (vm *Vm) WaitResponse(match matchResponse, timeout int) chan error {
-	result := make(chan error)
-	go func() {
-		var timeoutChan <-chan time.Time
-		if timeout >= 0 {
-			timeoutChan = time.After(time.Duration(timeout) * time.Second)
-		} else {
-			timeoutChan = make(chan time.Time, 1)
-		}
+	result := make(chan error, 1)
+	var timeoutChan <-chan time.Time
+	if timeout >= 0 {
+		timeoutChan = time.After(time.Duration(timeout) * time.Second)
+	} else {
+		timeoutChan = make(chan time.Time, 1)
+	}
 
-		Status, err := vm.GetResponseChan()
-		if err != nil {
-			result <- err
-			return
-		}
+	Status, err := vm.GetResponseChan()
+	if err != nil {
+		result <- err
+		return result
+	}
+	go func() {
 		defer vm.ReleaseResponseChan(Status)
 
 		for {


### PR DESCRIPTION
result := vm.WaitResponse()
send event to ctx.HUB
	[ the vm loop handles the event and sends a response event back,
	[ but vm.GetResponseChan() in the vm.WaitResponse() might be
	[ later than the response event, and the response event will not
	[ be caught, and the next statement will deadlock ]
<-result

fix it by moving vm.GetResponseChan() up (out of the go routine).

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>