### PR TITLE
Fix a nil pointer dereference in supervisor/container.go:199

### DIFF
--- a/supervisor/container.go
+++ b/supervisor/container.go
@@ -188,7 +188,7 @@ func (c *Container) wait(p *Process, result <-chan *api.ProcessExit) (*api.Proce
 	exit, ok := <-result
 	if !ok {
 		exit = nil
-		glog.V(1).Infof("get exit code failed %s\n", err.Error())
+		glog.V(1).Info("get exit code failed (channel already closed)")
 	}
 
 	err = execPoststopHooks(c.Spec, state)


### PR DESCRIPTION
This use of `err` is invalid, and crashes `runv` with a nil pointer deference when err was not set in the code above. It additionally means the wrong error message is printed (as the actual check is "channel closed" not `err`).