### PR TITLE
reject newcontainer and process when sandbox is closed

### DIFF
--- a/hyperstart/libhyperstart/serial.go
+++ b/hyperstart/libhyperstart/serial.go
@@ -66,11 +66,11 @@ func (h *serialBasedHyperstart) Close() {
 		for pk := range h.procs {
 			h.processAsyncEvents <- hyperstartapi.ProcessAsyncEvent{Container: pk.c, Process: pk.p, Event: "finished", Status: 255}
 		}
-		h.procs = nil
+		h.procs = make(map[pKey]*pState)
 		for _, out := range h.streamOuts {
 			out.Close()
 		}
-		h.streamOuts = nil
+		h.streamOuts = make(map[uint64]streamOut)
 		close(h.ctlChan)
 		close(h.streamChan)
 		close(h.processAsyncEvents)


### PR DESCRIPTION
Fixes panic:
```
panic(0x11a1ce0, 0xc4218baa70)
        /usr/local/go/src/runtime/panic.go:458 +0x243
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hyperstart/libhyperstart.(*serialBasedHyperstart).setupProcessIo(0xc421024af0, 0xc42118f6c0, 0xc420655100)
        /home/jenkins/workspace/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hyperstart/libhyperstart/serial.go:602 +0x19c
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hyperstart/libhyperstart.(*serialBasedHyperstart).AddProcess(0xc421024af0, 0xc4212a8340, 0x40, 0xc4215cec00, 0x3, 0xc4200add80, 0x2, 0x4, 0xc420648000, 0x7f0dfae2e000, ...)
        /home/jenkins/workspace/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hyperstart/libhyperstart/serial.go:655 +0x250
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*Vm).AddProcess(0xc4206bfb00, 0xc4212a8340, 0x40, 0xc4218ba830, 0xf, 0xc42118f600, 0xc42118f500, 0x2, 0x4, 0xc42118f640, ...)
```