### PR TITLE
s390x: Re-add RawSockaddrUnix structure

### DIFF
--- a/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
@@ -183,6 +183,14 @@ type RawSockaddrUnix struct {
 	Path   [108]int8
 }
 
+type RawSockaddrVsock struct {
+	Family   uint16
+	Reserved uint16
+	Port     uint32
+	Cid      uint32
+	Zero     [4]uint8
+}
+
 type RawSockaddrLinklayer struct {
 	Family   uint16
 	Protocol uint16


### PR DESCRIPTION
The structure has been removed by commit c88ed9c5c9a ("update vendor") for mips64, mips64_le, and s390x.

This leads to the following build error on s390x:

```
$ make
go build -tags "static_build  with_libvirt" -o runv .
# github.com/hyperhq/runv/vendor/golang.org/x/sys/unix
vendor/golang.org/x/sys/unix/syscall_unix.go:165: undefined: RawSockaddrVsock
make: *** [build-runv] Error 2
```
So re-add the structure to fix the build error.

Signed-off-by: Michael Holzheu <holzheu@linux.vnet.ibm.com>