### PR TITLE
Show commit and version numbers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,10 @@ else
 LIBVIRT_BUILD_TAG=
 endif
 
+COMMIT=`git describe --dirty --always --tags 2> /dev/null || true`
+GOLDFLAGS="-X main.gitCommit=${COMMIT} -X main.version=${VERSION}"
 HYPER_BULD_TAGS=$(XEN_BUILD_TAG) $(LIBVIRT_BUILD_TAG)
+
 all-local: build-runv
 clean-local:
 	-rm -f runv
@@ -19,7 +22,7 @@ install-exec-local:
 	$(INSTALL_PROGRAM) runv $(bindir)
 
 build-runv:
-	go build -tags "static_build $(HYPER_BULD_TAGS)" -o runv .
+	go build -tags "static_build $(HYPER_BULD_TAGS)" -ldflags ${GOLDFLAGS} -o runv .
 test-integration:
 	cd integration-test/test_data && make
 	cd integration-test && go test -check.v -test.timeout=120m ${TESTFLAGS} .

--- a/main.go
+++ b/main.go
@@ -20,8 +20,12 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
+var (
+	version   = ""
+	gitCommit = ""
+)
+
 const (
-	version    = "0.8.1"
 	specConfig = "config.json"
 	stateJson  = "state.json"
 	usage      = `Open Container Initiative hypervisor-based runtime
@@ -59,7 +63,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "runv"
 	app.Usage = usage
-	app.Version = version
+	app.Version = fmt.Sprintf("%s, commit: %s", version, gitCommit)
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "debug",


### PR DESCRIPTION
Print git commit hash id when run `runv -v`, this will be helpful for
debug.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

Examples:
```
$ ./runv -v
runv version 0.7.0, commit: v0.7.0-145-g23cbab6-dirty
```

Means version: 0.7.0, latest tag is v0.7.0, we are 145 commits forward from that tag, current git commit is 23cbab6, `dirty` means we have uncommited changes in repo when building the binary.