### PR TITLE
Add bios+cbfs support for runv

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -80,6 +80,8 @@ var ContainerdCommand = cli.Command{
 		driver := context.GlobalString("driver")
 		kernel := context.GlobalString("kernel")
 		initrd := context.GlobalString("initrd")
+		bios := context.GlobalString("bios")
+		cbfs := context.GlobalString("cbfs")
 		vsock := context.GlobalBool("vsock")
 		template := context.GlobalString("template")
 		stateDir := context.String("state-dir")
@@ -105,14 +107,16 @@ var ContainerdCommand = cli.Command{
 
 			if (driver != "" && driver != tconfig.Driver) ||
 				(kernel != "" && kernel != tconfig.Config.Kernel) ||
-				(initrd != "" && initrd != tconfig.Config.Initrd) {
-				glog.Warningf("template config is not match the driver, kernel or initrd argument, disable template")
+				(initrd != "" && initrd != tconfig.Config.Initrd) ||
+				(bios != "" && bios != tconfig.Config.Bios) ||
+				(cbfs != "" && cbfs != tconfig.Config.Cbfs) {
+				glog.Warningf("template config is not match the driver, kernel, initrd, bios or cbfs argument, disable template")
 				template = ""
 			} else if driver == "" {
 				driver = tconfig.Driver
 			}
-		} else if kernel == "" || initrd == "" {
-			glog.Error("argument kernel and initrd must be set")
+		} else if (bios == "" || cbfs == "") && (kernel == "" || initrd == "") {
+			glog.Error("argument kernel+initrd or bios+cbfs must be set")
 			os.Exit(1)
 		}
 
@@ -130,6 +134,8 @@ var ContainerdCommand = cli.Command{
 			bootConfig := hypervisor.BootConfig{
 				Kernel:      kernel,
 				Initrd:      initrd,
+				Bios:        bios,
+				Cbfs:        cbfs,
 				EnableVsock: vsock,
 			}
 			f = singlefactory.Dummy(bootConfig)

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/reexec"
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperhq/runv/containerd"
 	"github.com/hyperhq/runv/containerd/api/grpc/types"
@@ -110,6 +111,14 @@ func main() {
 			Usage: "runv-compatible initrd for the container",
 		},
 		cli.StringFlag{
+			Name:  "bios",
+			Usage: "bios for the container",
+		},
+		cli.StringFlag{
+			Name:  "cbfs",
+			Usage: "cbfs for the container",
+		},
+		cli.StringFlag{
 			Name:  "template",
 			Usage: "path to the template vm state directory",
 		},
@@ -132,6 +141,11 @@ func main() {
 		}
 		return nil
 	}
+	app.After = func(context *cli.Context) error {
+		// make sure glog flush all the messages to file
+		glog.Flush()
+		return nil
+	}
 
 	app.Commands = []cli.Command{
 		createCommand,
@@ -147,7 +161,7 @@ func main() {
 		containerd.ContainerdCommand,
 	}
 	if err := app.Run(os.Args); err != nil {
-		fmt.Printf("%s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "%v", err)
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli"
+)
+
+const (
+	defaultKernelInstallDir string = "/var/lib/hyper"
+)
+
+func firstExistingFile(candidates []string) string {
+	for _, file := range candidates {
+		if _, err := os.Stat(file); err == nil {
+			return file
+		}
+	}
+	return ""
+}
+
+func getDefaultBundlePath() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return cwd
+}
+
+// getKernelFiles chooses kernel/initrd/bios/cbfs files based on user specified ones
+func getKernelFiles(context *cli.Context, rootPath string) (string, string, string, string, error) {
+	kernel := context.GlobalString("kernel")
+	initrd := context.GlobalString("initrd")
+	bios := context.GlobalString("bios")
+	cbfs := context.GlobalString("cbfs")
+	bundle := context.String("bundle")
+
+	for k, v := range map[*string][]string{
+		&kernel: {
+			filepath.Join(bundle, rootPath, "boot/vmlinuz"),
+			filepath.Join(bundle, "boot/vmlinuz"),
+			filepath.Join(bundle, "vmlinuz"),
+			filepath.Join(defaultKernelInstallDir, "kernel"),
+		},
+		&initrd: {
+			filepath.Join(bundle, rootPath, "boot/initrd.img"),
+			filepath.Join(bundle, "boot/initrd.img"),
+			filepath.Join(bundle, "initrd.img"),
+			filepath.Join(defaultKernelInstallDir, "hyper-initrd.img"),
+		},
+		&bios: {
+			filepath.Join(bundle, rootPath, "boot/bios.bin"),
+			filepath.Join(bundle, "boot/bios.bin"),
+			filepath.Join(bundle, "bios.bin"),
+			filepath.Join(defaultKernelInstallDir, "bios.bin"),
+		},
+		&cbfs: {
+			filepath.Join(bundle, rootPath, "boot/cbfs.rom"),
+			filepath.Join(bundle, "boot/cbfs.rom"),
+			filepath.Join(bundle, "cbfs.rom"),
+			filepath.Join(defaultKernelInstallDir, "cbfs.rom"),
+		},
+	} {
+		if *k == "" {
+			*k = firstExistingFile(v)
+		}
+		if *k != "" {
+			var err error
+			*k, err = filepath.Abs(*k)
+			if err != nil {
+				return "", "", "", "", fmt.Errorf("cannot get abs path for kernel files: %v", err)
+			}
+		}
+	}
+
+	return kernel, initrd, bios, cbfs, nil
+}


### PR DESCRIPTION
Export and Support starting VM with bios+cbfs from runv command line,
also use CBFS as first choice when kernel also exists.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>