### PR TITLE
Make VM dir private to avoid unnecessary propagation

### DIFF
--- a/supervisor/hyperpod.go
+++ b/supervisor/hyperpod.go
@@ -526,5 +526,7 @@ func (hp *HyperPod) reap() {
 	}
 
 	hp.stopNsListener()
-	os.RemoveAll(filepath.Join(hypervisor.BaseDir, hp.vm.Id))
+	if err := os.RemoveAll(filepath.Join(hypervisor.BaseDir, hp.vm.Id)); err != nil {
+		glog.Errorf("can't remove vm dir %q: %v", filepath.Join(hypervisor.BaseDir, hp.vm.Id), err)
+	}
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -157,7 +157,7 @@ func (sv *Supervisor) reap(container, processId string) {
 	defer sv.Unlock()
 	if c, ok := sv.Containers[container]; ok {
 		if p, ok := c.Processes[processId]; ok {
-			go p.reap()
+			p.reap()
 			delete(c.ownerPod.Processes, p.inerId)
 			delete(c.Processes, processId)
 			if p.init {
@@ -165,12 +165,12 @@ func (sv *Supervisor) reap(container, processId string) {
 			}
 		}
 		if len(c.Processes) == 0 {
-			go c.reap()
+			c.reap()
 			delete(c.ownerPod.Containers, container)
 			delete(sv.Containers, container)
 		}
 		if len(c.ownerPod.Containers) == 0 {
-			go c.ownerPod.reap()
+			c.ownerPod.reap()
 		}
 	}
 }


### PR DESCRIPTION
We need to make the `/run/hyper/vm-xxxx/share_dir/container_id` private before
starting the container, or the mountpoint could propagate unexpectly,
and makes devicemapper device busy to umount.

Also move some codes out from goroutine, because we need a certain
process sequence to handle the clean works, goroutine can't gurantee the
sequence, which sometime will leave trash in our system, this is quite
bad.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>