### PR TITLE
use hypercontaienr-utils/hlog instead of glog for some cases

### DIFF
--- a/hack/validate-vet.sh
+++ b/hack/validate-vet.sh
@@ -4,7 +4,7 @@ files=( $(find . -path ./vendor -prune -o -name "*.go" -print) )
 
 errors=()
 for f in "${files[@]}"; do
-	failedVet=$(go vet "$f" 2>&1)
+	failedVet=$(go tool vet --printf=false "$f" 2>&1)
     if [ "$failedVet" ]; then
         errors+=( "$failedVet" )
     fi


### PR DESCRIPTION
context info will be well formatted.

And add some logs for the keep-alive check.

Signed-off-by: Wang Xu <gnawux@gmail.com>