### PR TITLE
[DO NOT MERGE]Add full runv functional test(oci compatible)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,7 @@ matrix:
     - go: 1.7
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq autoconf automake pkg-config libdevmapper-dev libvirt-dev libvirt-bin wget libaio1 libpixman-1-0
-  - wget https://s3-us-west-1.amazonaws.com/hypercontainer-download/qemu-hyper/qemu-hyper_2.4.1-1_amd64.deb && sudo dpkg -i --force-all qemu-hyper_2.4.1-1_amd64.deb
-  - git clone https://github.com/hyperhq/hyperstart.git ${GOPATH}/src/github.com/hyperhq/hyperstart
+  - cd ${TRAVIS_BUILD_DIR} && hack/ci-setup.sh
 
 # override the default `install`, otherwise default `install` will export ${TRAVIS_BUILD_DIR}/Godeps/_workspace as GOPATH
 # see https://docs.travis-ci.com/user/languages/go#Dependency-Management
@@ -21,7 +18,11 @@ install:
   - cd ${TRAVIS_BUILD_DIR}
   - hack/verify-gofmt.sh
   - hack/validate-vet.sh
-  - ./autogen.sh && ./configure && make && sudo GOPATH=${GOPATH} PATH=${PATH} GOROOT=${GOROOT} make install
+  - ./autogen.sh && ./configure --without-xen && sudo GOPATH=${GOPATH} PATH=${PATH} GOROOT=${GOROOT} make install
 
 script:
-  - cd ${TRAVIS_BUILD_DIR} && sudo GOPATH=${GOPATH} PATH=${PATH} GOROOT=${GOROOT} hack/test-cmd.sh
+    #- cd ${TRAVIS_BUILD_DIR} && sudo GOPATH=${GOPATH} PATH=${PATH} GOROOT=${GOROOT} hack/test-cmd.sh
+  - hack/functional-test.sh
+
+after_failure:
+  - hack/.ci/ci-teardown.sh

--- a/hack/.cc-configure.sh
+++ b/hack/.cc-configure.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2017 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+set -e -x
+
+source $(dirname "$0")/lib/ci-common.sh
+
+cd $CC_ROOT
+
+configure_opts=""
+
+# disable uesless ones for runv
+configure_opts+=" --disable-code-coverage"
+configure_opts+=" --disable-tests"
+configure_opts+=" --disable-cppcheck"
+configure_opts+=" --disable-valgrind"
+configure_opts+=" --disable-valgrind-helgrind"
+configure_opts+=" --disable-valgrind-drd"
+configure_opts+=" --disable-silent-rules"
+
+# additional controls
+configure_opts+=" --srcdir=\"${CC_ROOT}\""
+configure_opts+=" --enable-auto-bundle-creation"
+configure_opts+=" --with-auto-bundle-creation-path=\"${BUNDLE_PATH}\""
+# fake hyperstart initrd as clear containers image
+configure_opts+=" --with-cc-image=\"${HYPERSTART_INITRD}\""
+# fake hyperstart kernel as clear containers kernel
+configure_opts+=" --with-cc-kernel=\"${HYPERSTART_KERNEL}\""
+
+# Test enable
+configure_opts+=" --enable-functional-tests"
+
+eval ./autogen.sh "$configure_opts"

--- a/hack/.ci/fake_cc_root/tests/functional/common.bash.in
+++ b/hack/.ci/fake_cc_root/tests/functional/common.bash.in
@@ -216,7 +216,7 @@ function run_cmd(){
 
 	if [ "$timeout_cmd"  -eq "$timeout_cmd" ] 2> /dev/null
 	then
-		cmd="timeout $timeout_cmd $cmd"
+		cmd="sudo timeout $timeout_cmd $cmd"
 	fi
 	log_msg "Running: $cmd"
 	eval "$cmd" 2>&1

--- a/hack/.ci/fake_cc_root/tests/functional/common.bash.in
+++ b/hack/.ci/fake_cc_root/tests/functional/common.bash.in
@@ -1,0 +1,351 @@
+#!/bin/bash
+
+source "@srcdir@/.ci/ci-common.sh"
+
+RUNV_BINARY="/usr/local/bin/runv"
+
+# Make temporal tests directory
+function mktemp_tests_dir(){
+	mktemp -d --tmpdir="$BATS_TMPDIR" --suffix=-cor-test
+}
+
+# Test data dir.
+TEST_DATA_DIR="$(readlink -e "${BATS_TEST_DIRNAME}")/data"
+#Configuration files
+CONFIG="${TEST_DATA_DIR}/config-minimal-cc-oci.json"
+
+BUNDLE_DIR="@BUNDLE_TEST_PATH@"
+[ -n "$BUNDLE_DIR" ] && ROOTFS_DIR="$BUNDLE_DIR/rootfs"
+HYPERSTART_INITRD="@CONTAINERS_IMG@"
+HYPERSTART_KERNEL="@CONTAINER_KERNEL@"
+HYPERVISOR_PATH="@QEMU_PATH@"
+
+# Verify components needed by Clear Containers
+# If there is a missing component, the tests is skipped
+function check_ccontainers() {
+
+	if [ ! -d "$BUNDLE_DIR" ]
+	then
+		skip "bundle directory does not exist,\
+ provide a valid bundle in $BUNDLE_DIR"
+	elif [ ! -d "$ROOTFS_DIR" ]
+	then
+		skip "$ROOTFS_DIR directory does not exist,\
+ provide a rootfs"
+	elif [ ! -f "$HYPERSTART_INITRD" ]
+	then
+		skip "hyperstart initrd image $HYPERSTART_INITRD does\
+ not exist, provide an image"
+	elif [ ! -f "$HYPERSTART_KERNEL" ]
+	then
+		skip "hyperstart kernel $HYPERSTART_KERNEL does\
+ not exist, provide a kernel"
+	elif [ ! -x "$HYPERVISOR_PATH" ]
+	then
+		 skip "execute permission is not granted: $HYPERVISOR_PATH"
+	fi
+
+	for f in  $BUNDLE_DIR $ROOTFS_DIR
+	do
+		[ -r "$f" ] || skip "cannot read file $f"
+		[ -w "$f" ] || skip "write permission is not granted: $f"
+	done
+
+	cd "$BATS_TEST_DIRNAME"
+}
+
+# Verify the state of the runtime directories
+# @param <container-id>
+# @param <state> container state (created, running, paused,
+#   stopped or killed).
+function verify_runtime_dirs()
+{
+	local id="$1"
+	local state="$2"
+
+	local id_dir="$RUNV_ROOT_DIR/${id}"
+
+	local statefile="$id_dir/state.json"
+#	local console_sock="$id_dir/console.sock"
+#	local hypervisor_sock="$id_dir/hypervisor.sock"
+#	local process_sock="$id_dir/process.sock"
+
+	# common tests
+
+	[ -f "$RUNV_LOG_FILE" ]
+	[ -r "$RUNV_LOG_FILE" ]
+	[ -s "$RUNV_LOG_FILE" ]
+
+	if [ "$state" = "deleted" ]; then
+	    [ ! -d "$id_dir" ]
+	    return 0
+	fi
+
+	if [ "$state" = "stopped" ]
+	then
+        # TODO add check once vm root is ready
+		# If a container is stopped, all container-specific
+		# state is removed.
+		[ ! -d "$id_dir" ]
+
+		return 0
+	fi
+
+	[ -d "$id_dir" ]
+
+	[ -f "$statefile" ]
+	[ -r "$statefile" ]
+	[ -s "$statefile" ]
+
+	run ls $id_dir
+	[ "$status" -eq 0 ]
+
+	# state-specific tests
+	# 'kill' does not kill the VM just kill the container
+	# inside it
+	if [ "$state" = "killed" -o "$state" = "created" -o \
+				  "$state" = "running" -o "$state" = "paused" ]
+	then
+        # TODO add check once vm root is ready
+        echo "pass"
+		#[ "${lines[0]}" = "console.sock" ]
+		#[ "${lines[3]}" = "hypervisor.sock" ]
+		#[ "${lines[4]}" = "process.sock" ]
+		#[ "${lines[5]}" = "state.json" ]
+		#[ "${lines[6]}" = "" ]
+
+		#[ -S "$console_sock" ]
+		#[ -S "$hypervisor_sock" ]
+		#[ -S "$process_sock" ]
+	else
+		log_msg "Invalid state: '$state'"
+		false
+	fi
+
+	return 0
+}
+
+# Verify a container state
+# @param <container-id>
+# @param <status>  container status to check (created, running,
+#   paused, stopped or killed).
+# @param <timeout> timeout to check container status
+# return true if containter have the <status>, false if
+#        the status is not the expected after timeout
+function testcontainer() {
+	local container_id="$1"
+	local status="$2"
+	local timeout_cmd=${3:-5}
+	local i=0
+	local got=0
+	local cmd="$COR list --format table"
+	[ "$timeout_cmd"  -eq "$timeout_cmd" ] || \
+	{ log_msg "timeout is not a number"; false; }
+
+	# The status passed to this function needs to be "simplified"
+	# in the case of "killed" to match the acceptable OCI states
+	# when checking the state the runtime assigns to the container.
+	if [ "$status" = "killed" ]
+	then
+		check_status="stopped"
+	else
+		check_status="$status"
+	fi
+
+	while [ "$i" -lt "$timeout_cmd" ]
+	do
+		local output=$(run_cmd "$cmd | grep ${container_id} | grep ${check_status}")
+		if [ -n "${output}" ] 
+		then
+			got=1
+			#Wait at least one second, for vm bootime
+			#Cor spawns the hypervisor but it does not mean
+			#That the vm is ready to work
+			#Clear containres must boot in less than one second
+			sleep 1
+			break
+		fi
+		sleep 1
+		i=$((i+1))
+	done
+	[ "$got" -eq 1 ] || { log_msg "FAILED"; false; }
+	log_msg "SUCCESS"
+
+	# Pass full status to the verify function
+	verify_runtime_dirs "$container_id" "$status"
+}
+
+# Check if test is running as root, if not
+# the test will be skipped
+function check_root() {
+	if [[ $(id -u) -ne 0 ]]
+	then
+		skip "Test requires root"
+	fi
+}
+
+#Modify config.json's workload to execute a <cmd>
+# @param <cmd>
+# @param <options> ...
+function workload_cmd() {
+	#Copy new, no modified config.json
+	/bin/cp "$CONFIG" "${BUNDLE_DIR}/config.json"
+	local cmd="\"$1\""
+	local opt
+	shift
+	for opt in "$@"
+	do
+	    cmd="$cmd\, \"$opt\""
+	done
+	sed -i "s,\"CMD\",$cmd,g" "$BUNDLE_DIR/config.json"
+}
+
+# Execute a command and vefiy its exit code
+# if exit code is not the expected
+# the current tests will fail
+# @param cmd command to run
+# @param expected_exit_code expected exit code
+# @param timeout time to wait before kill command
+function run_cmd(){
+	local cmd="$1"
+	local expected_exit_code="${2:-0}"
+	local timeout_cmd="$3"
+
+	#Remove -e from bats enviroment
+	set +e
+
+	if [ "$timeout_cmd"  -eq "$timeout_cmd" ] 2> /dev/null
+	then
+		cmd="timeout $timeout_cmd $cmd"
+	fi
+	log_msg "Running: $cmd"
+	eval "$cmd" 2>&1
+	local exit_code="$?"
+	log_msg "exit code: $exit_code"
+	log_msg "expected exit code: $expected_exit_code"
+
+	if [ ! "$exit_code" -eq "$expected_exit_code" ]
+	then
+		if [ -f "$RUNV_LOG_FILE" ]
+		then
+			log_msg "See $TEST_LOG_FILE"
+			cat "$RUNV_LOG_FILE" >> "$TEST_LOG_FILE"
+			cor_ci_env && cat "$TEST_LOG_FILE"
+		fi
+	fi
+	#Restore -e from bats enviroment
+	set -e
+	[ "$exit_code" -eq "$expected_exit_code" ]
+}
+
+function log_msg()
+{
+	local msg="$*"
+	echo "$msg" >&2
+}
+
+# Display the name of a logfile, but if running in a CI environment,
+# also show the log file contents.
+#
+# Param 1: prefix - a human-readable string to be used to introduce
+#   the file to be logged.
+# Param 2: file - path to file to be logged.
+function log_show_file()
+{
+	local prefix="$1"
+	local file="$2"
+
+	[ -z "$prefix" ] && prefix="See"
+
+	log_msg "${prefix}: ${file}"
+
+	# CI systems don't all allow remote access, so display
+	# the file to make debugging easier.
+	cor_ci_env && cat "${file}"
+}
+
+# Common setup for all the tests
+function setup_common(){
+	# save IFS to work around bats bug where IFS is corrupted.
+	[ -z "$OLD_IFS" ] && OLD_IFS=$IFS
+
+	# container-specific directory
+	RUNV_ROOT_DIR=$(mktemp_tests_dir)
+
+	RUNV_LOG_DIR=$(mktemp_tests_dir)
+    RUNV_LOG_FILE="$RUNV_ROOT_DIR/runv.INFO"
+
+	RUNV_ARGS=""
+
+	# always run in debug mode to make problem diagnosis easier
+	RUNV_ARGS="$RUNV_ARGS --debug"
+
+	# Give each container its own directory.
+	# (Note that the arguments to these options must *NOT* be
+	# quoted else odd bats behaviour results).
+	RUNV_ARGS="$RUNV_ARGS --root $RUNV_ROOT_DIR"
+
+	RUNV_ARGS="$RUNV_ARGS --log_dir $RUNV_LOG_DIR"
+	RUNV_ARGS="$RUNV_ARGS --initrd \"${HYPERSTART_INITRD}"\"
+	RUNV_ARGS="$RUNV_ARGS --kernel \"${HYPERSTART_KERNEL}"\"
+    # TODO Support hypervisor driver config here
+
+    # COR == RUNV
+	COR="$RUNV_BINARY $RUNV_ARGS"
+
+	TEST_LOG_FILE="$(pwd)/${BATS_TEST_NAME// /.}.log"
+	if [ -f "$TEST_LOG_FILE" ]
+	then
+		rm "$TEST_LOG_FILE"
+	fi
+}
+
+# Cleanup anything generated by this script
+function cleanup_common(){
+	# kill shim if it is still running
+	#local pid="$(cat ${RUNV_ROOT_DIR}/pid)"
+	#if ["${pid}" -a -n "$(ps -e | grep ${pid})" ]; then
+	#	(>&2 echo "cc-shim is still running")
+	#	kill -15 ${pid}
+	#	BATS_ERROR_STATUS=1
+	#fi
+	if [ "$BATS_ERROR_STATUS" -ne 0 ]
+	then
+		log_msg "Test logs: $RUNV_LOG_FILE"
+
+		#if cor_ci_env
+		#then
+		#	(cd "$RUNV_ROOT_DIR" && for file in *; do echo "== $file =="; cat "$file"; done)
+		#fi
+
+		log_show_file "Global log file" "$RUNV_LOG_FILE"
+
+		log_msg "bats status: $status"
+		log_msg "bats output (lines array contains ${#lines[*]} lines):"
+
+		local i=0
+		local line
+
+		for line in ${lines[@]}
+		do
+			echo >&2 "lines[$i]: '$line'"
+			i=$((i+1))
+		done
+
+		echo >&2 "BUNDLE_DIR: $BUNDLE_DIR"
+		echo >&2 "ROOTFS_DIR: $ROOTFS_DIR"
+
+		# XXX: retain logs if tests fail
+		return
+	fi
+
+	rm -rf "$RUNV_ROOT_DIR" "$RUNV_LOG_DIR"
+}
+
+if [ ! -e "$RUNV_BINARY" ]
+then
+	cat <<EOT >&2
+ERROR: you need run 'make' before running the functional tests.
+EOT
+	exit 1
+fi

--- a/hack/.ci/fake_cc_root/tests/functional/data/config-minimal-cc-oci.json.in
+++ b/hack/.ci/fake_cc_root/tests/functional/data/config-minimal-cc-oci.json.in
@@ -1,0 +1,62 @@
+{
+	"ociVersion": "0.6.0",
+	"platform": {
+		"os": "linux",
+		"arch": "amd64"
+	},
+	"process": {
+		"terminal": false,
+		"user": {
+			"uid": 0,
+			"gid": 0
+		},
+		"args": [
+			"CMD"
+		],
+		"env": [
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm"
+		],
+		"cwd": "/"
+	},
+	"root": {
+		"path": "@ROOTFS_PATH@",
+		"readonly": true
+	},
+	"hostname": "shell",
+	"mounts": [],
+    "linux": {
+	    "namespaces": [
+	    	{"type":"mount"},
+	    	{"type":"network"},
+	    	{"type":"uts"},
+	    	{"type":"pid"},
+	    	{"type":"ipc"}
+	    ]
+    },
+	"hooks": {
+		"prestart": [
+		{
+			"path": "/bin/echo",
+			"args": ["/bin/echo", "this", "is", "a", "test"],
+			"env":  [ "key1=value1"]
+		},
+		{
+			"path": "/bin/ls"
+		}
+		],
+		"poststart": [
+		{
+			"path": "/bin/ls",
+			"timeout": 5
+		}
+		],
+		"poststop": [
+		{
+			"path": "/bin/echo",
+			"args": ["/bin/echo", "other", "test"]
+		}
+		]
+	}
+
+}

--- a/hack/.ci/fake_cc_root/tests/functional/help.bats
+++ b/hack/.ci/fake_cc_root/tests/functional/help.bats
@@ -1,0 +1,1 @@
+#!/usr/bin/env bats

--- a/hack/.ci/fake_cc_root/tests/functional/run-functional-tests.sh.in
+++ b/hack/.ci/fake_cc_root/tests/functional/run-functional-tests.sh.in
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+bash @ABS_BUILDDIR@/data/run-bats.sh @ABS_BUILDDIR@/tests/functional/
+functional_tests_exit_code="$?"
+exit "$functional_tests_exit_code"

--- a/hack/.ci/fake_cc_root/tests/functional/start.bats
+++ b/hack/.ci/fake_cc_root/tests/functional/start.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+load common
+
+function setup() {
+	setup_common
+	#Start use Clear Containers
+	check_ccontainers
+	#Default timeout for cor commands
+	COR_TIMEOUT=5
+	container_id="tests_id"
+}
+
+function teardown() {
+	cleanup_common
+}
+
+@test "start without container id" {
+	run $COR start
+	[ "$status" -ne 0 ]
+	[[ "${output}" =~ "Please specify container ID" ]]
+}
+
+@test "start with invalid container id" {
+	run $COR start FOO
+	[ "$status" -ne 0 ]
+	[[ "${output}" =~ "no such file or directory" ]]
+}
+
+@test "run without params" {
+	run $COR run
+	[ "$status" -ne 0 ]
+    [[ "${output}" =~ "load config failed:" ]]
+}
+
+@test "run detach pid file" {
+	workload_cmd "sh"
+
+	# 'run' runs in background since it will
+	# update the state file once shim ends
+	cmd="$COR run -d --pid-file ${COR_ROOT_DIR}/pid --bundle $BUNDLE_DIR $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	sleep 2
+	[ -f "${COR_ROOT_DIR}/pid" ]
+
+	cmd="$COR kill $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "killed"
+
+	cmd="$COR delete $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	verify_runtime_dirs "$container_id" "deleted"
+}

--- a/hack/.ci/fake_cc_root/tests/functional/state.bats
+++ b/hack/.ci/fake_cc_root/tests/functional/state.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+load common
+
+function setup() {
+	setup_common
+	check_ccontainers
+	COR_TIMEOUT=5
+	container_id="tests_id"
+}
+
+function teardown() {
+	cleanup_common
+}
+
+# Run and verify state output
+# @param <container-id>
+# @param <status> container state to verify (running, created ...)
+function check_state() {
+	container_id_state="$1"
+	status="$2"
+	#COR must store resolved paths to cc components
+	bundle_path=$(readlink -e "${BUNDLE_DIR}")
+
+	state_cmd="$COR state $container_id_state"
+	local output=$(run_cmd "$state_cmd" "0" "$COR_TIMEOUT")
+	[ -n "$(echo "$output" | grep -o "\"id\" : \"${container_id_state}\"")" ]
+	[ -n "$(echo "$output" | grep -o "\"bundlePath\" : \"${bundle_path}\"")" ]
+	[ -n "$(echo "$output" | grep -o "\"status\" : \"${status}\"")" ]
+}
+
+@test "start and kill state" {
+	workload_cmd "sh"
+
+	cmd="$COR create --bundle $BUNDLE_DIR $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "created"
+	check_state "$container_id" "created"
+
+	# 'start' runs in background since it will
+	# update the state file once shim ends
+	cmd="$COR start $container_id &"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "running"
+	check_state "$container_id" "running"
+
+	cmd="$COR kill $container_id 15"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	testcontainer "$container_id" "killed"
+	check_state "$container_id" "stopped"
+
+	cmd="$COR delete $container_id"
+	run_cmd "$cmd" "0" "$COR_TIMEOUT"
+	verify_runtime_dirs "$container_id" "deleted"
+}
+
+@test "state not existing container" {
+
+	state_cmd="$COR state $container_id"
+	run_cmd "$state_cmd" "1" "$COR_TIMEOUT"
+}

--- a/hack/.ci/fake_cc_root/tests/functional/version.bats
+++ b/hack/.ci/fake_cc_root/tests/functional/version.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+#  This file is part of cc-oci-runtime.
+#
+#  Copyright (C) 2016 Intel Corporation
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+load common
+
+function setup() {
+	version_regex="([0-9]|\.|-|[a-z])+"
+	setup_common
+}
+
+function teardown() {
+	cleanup_common
+}
+
+@test "runv -v" {
+	run $COR -v
+	[ "$status" -eq 0 ]
+	echo "${lines[0]}" | grep -P "runv\s+version\s+$version_regex"
+}
+
+@test "runv --version" {
+	run $COR --version
+	[ "$status" -eq 0 ]
+	echo "${lines[0]}" | grep -P "runv\s+version\s+$version_regex"
+}

--- a/hack/ci-setup.sh
+++ b/hack/ci-setup.sh
@@ -43,14 +43,12 @@ pkgs+=" valgrind"
 pkgs+=" libdevmapper-dev"
 pkgs+=" libvirt-dev"
 pkgs+=" libvirt-bin"
-pkgs+=" qemu"
 
 # runtime dependencies
 pkgs+=" uuid-dev"
 pkgs+=" libmnl-dev"
 pkgs+=" libffi-dev"
 pkgs+=" libpcre3-dev"
-pkgs+=" qemu-system-x86"
 
 # runtime + qemu-lite
 pkgs+=" zlib1g-dev"
@@ -81,6 +79,8 @@ pkgs+=" libgpgme11-dev"
 
 sudo apt-get -qq update
 eval sudo apt-get -qq install "$pkgs"
+
+wget https://s3-us-west-1.amazonaws.com/hypercontainer-download/qemu-hyper/qemu-hyper_2.4.1-1_amd64.deb && sudo dpkg -i --force-all qemu-hyper_2.4.1-1_amd64.deb
 
 function cheat_cc_setup(){
     # clone specified commit cc-oci-runtime repo

--- a/hack/ci-setup.sh
+++ b/hack/ci-setup.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+set -e -x
+
+root=$(cd `dirname "$0"`/..; pwd -P)
+source $(dirname "$0")/lib/ci-common.sh
+source $(dirname "$0")/lib/hyperstart.sh
+
+if [ "$SEMAPHORE" = true ]
+then
+    # SemaphoreCI has different environments that builds can run in. The
+    # default environment does not have docker enabled so it is
+    # necessary to specify a docker-enabled build environment on the
+    # semaphoreci.com web site.
+    #
+    # However, currently, the docker-enabled environment does not
+    # provide nested KVM (whereas the default environment does), so
+    # manually enable nested kvm for the time being.
+    sudo rmmod kvm-intel || :
+    sudo sh -c "echo 'options kvm-intel nested=y' >> /etc/modprobe.d/dist.conf" || :
+    sudo modprobe kvm-intel || :
+fi
+
+if [ "$nested" = "Y" ]
+then
+    # Ensure the user can access the kvm device
+    sudo chmod g+rw /dev/kvm
+    sudo chgrp "$USER" /dev/kvm
+fi
+
+pkgs=""
+
+# general
+pkgs+=" autoconf"
+pkgs+=" automake"
+pkgs+=" libtool"
+pkgs+=" pkg-config"
+pkgs+=" gettext"
+pkgs+=" rpm2cpio"
+pkgs+=" valgrind"
+
+# runv dependencies
+pkgs+=" libdevmapper-dev"
+pkgs+=" libvirt-dev"
+pkgs+=" libvirt-bin"
+pkgs+=" qemu"
+
+# runtime dependencies
+pkgs+=" uuid-dev"
+pkgs+=" libmnl-dev"
+pkgs+=" libffi-dev"
+pkgs+=" libpcre3-dev"
+pkgs+=" qemu-system-x86"
+
+# runtime + qemu-lite
+pkgs+=" zlib1g-dev"
+
+# qemu-lite
+pkgs+=" libpixman-1-dev"
+
+# gcc
+pkgs+=" libcap-ng-dev"
+pkgs+=" libgmp-dev"
+pkgs+=" libmpfr-dev"
+pkgs+=" libmpc-dev"
+
+# code coverage
+pkgs+=" lcov"
+
+# chronic(1)
+pkgs+=" moreutils"
+
+# CRI-O
+pkgs+=" libseccomp2"
+pkgs+=" libseccomp-dev"
+pkgs+=" seccomp"
+pkgs+=" libdevmapper-dev"
+pkgs+=" libdevmapper1.02.1"
+pkgs+=" libgpgme11"
+pkgs+=" libgpgme11-dev"
+
+sudo apt-get -qq update
+eval sudo apt-get -qq install "$pkgs"
+
+function cheat_cc_setup(){
+    # clone specified commit cc-oci-runtime repo
+    [ ! -d $CC_ROOT ] && git clone https://github.com/01org/cc-oci-runtime.git $CC_ROOT
+    cd $CC_ROOT
+    git checkout ae8e37e48cdeb6d88d1b2a362b8797bd72037f83
+
+    # replace some files to suite for runv
+    cp -r -v $root/hack/.ci/fake_cc_root/* $CC_ROOT/
+
+    # patch Makefile.am
+    sed '/AC_INIT(/a\AC_CONFIG_AUX_DIR([m4])' -i $CC_ROOT/configure.ac
+    sed '/PKG_CHECK_MODULES(/d' -i $CC_ROOT/configure.ac
+    sed '/AS_IF(\[test "$have_required_glib"/d' -i $CC_ROOT/configure.ac
+    # inject runv test target into cc Makefile
+    cat >> $CC_ROOT/Makefile.am <<EOF 
+
+runv-generate: \$(GENERATED_FILES)
+
+runv-functional: runv-generate \$(BUNDLE_TEST_PATH)
+		\$(AM_V_GEN)test -n "\$(BUNDLE_TEST_PATH)" && \\
+			echo "Using bundle '\$(BUNDLE_TEST_PATH)'" || true
+		@if [ "\$(builddir)" != "\$(srcdir)" ]; then \\
+			rm -f \$(builddir)/tests/functional/*.bats ; \\
+			for f in \$(abs_top_srcdir)/tests/functional/*.bats; do \\
+				ln -s \$\$f \$(builddir)/tests/functional/ ; \\
+			done; \\
+		fi
+		@bash -f \$(abs_builddir)/tests/functional/run-functional-tests.sh
+
+runv-test: runv-functional
+
+EOF
+}
+
+function setup_tools(){
+    cd $CC_ROOT/installation
+    source ./installation-setup.sh
+
+    # Install bats
+    bats_setup
+
+    # Build glib
+    glib_setup
+
+    # Build json-glib
+    json-glib_setup
+
+    # Build check
+    # We need to build check as the check version in the OS used by travis isn't
+    # -pedantic safe.
+    if ! lib_installed "check" "${check_version}"
+    then
+        file="check-${check_version}.tar.gz"
+
+        if [ ! -e "$file" ]
+        then
+            curl -L -O "https://github.com/libcheck/check/releases/download/${check_version}/$file"
+        fi
+
+        compile check check-${check_version}.tar.gz check-${check_version}
+    fi
+}
+
+cheat_cc_setup
+
+cd $CC_ROOT/installation
+source ./installation-setup.sh
+bats_setup
+#setup_tools
+
+hyper::hyperstart::build

--- a/hack/ci-teardown.sh
+++ b/hack/ci-teardown.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+source $(dirname "$0")/lib/ci-common.sh
+
+[ "$SEMAPHORE_THREAD_RESULT" = "passed" ] && exit 0
+
+printf "=== Build failed ===\n"
+
+cd "$ci_build_dir"
+
+for f in test-suite.log $(ls *_test*.log)
+do
+    printf "\n=== Log file: '$f' ===\n\n"
+    cat "$f"
+done

--- a/hack/functional-test.sh
+++ b/hack/functional-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e -x
+
+source $(dirname "$0")/.cc-configure.sh
+
+(cd "$CC_ROOT" \
+    && make runv-test)

--- a/hack/lib/ci-common.sh
+++ b/hack/lib/ci-common.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Return true if currently running in a recognised CI environment
+cor_ci_env()
+{
+    # Set by TravisCI and SemaphoreCI
+    [ "$CI" = true ]
+}
+
+nested=$(cat /sys/module/kvm_intel/parameters/nested 2>/dev/null \
+    || echo N)
+
+# Do not display output if this file is sourced via a BATS test since it
+# will cause the test to fail.
+[ -z "$BATS_TEST_DIRNAME" ] && echo "INFO: Nested kvm available: $nested"
+
+if [ -n "$SEMAPHORE_CACHE_DIR" ]
+then
+    # Running under SemaphoreCI
+    prefix_dir="$SEMAPHORE_CACHE_DIR/cor"
+else
+    prefix_dir="$HOME/.cache/cor"
+fi
+
+deps_dir="${prefix_dir}/dependencies"
+cor_ci_env && mkdir -p "$deps_dir" || :
+
+RUNV_ROOT=$(cd `dirname "${BASH_SOURCE}"`/../..; pwd -P)
+CC_ROOT=${GOPATH}/src/github.com/01org/cc-oci-runtime
+BUNDLE_PATH=$CC_ROOT/bundle
+HYPERSTART_KERNEL=$RUNV_ROOT/integration-test/test_data/kernel
+HYPERSTART_INITRD=$RUNV_ROOT/integration-test/test_data/hyper-initrd.img
+
+export LD_LIBRARY_PATH="${prefix_dir}/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="${prefix_dir}/lib/pkgconfig:$PKG_CONFIG_PATH"
+export PATH="${prefix_dir}/bin:${prefix_dir}/sbin:$PATH"
+
+# Directory to run build and tests in.
+#
+# An out-of-tree build is used to ensure all necessary files for
+# building and testing are distributed and to check srcdir vs builddir
+# discrepancies.
+if [ -n "$SEMAPHORE_PROJECT_DIR" ]
+then
+    ci_build_dir="$SEMAPHORE_PROJECT_DIR/ci_build"
+else
+    ci_build_dir="$TRAVIS_BUILD_DIR/ci_build"
+fi
+
+cor_ci_env && mkdir -p "$ci_build_dir" || :

--- a/hack/lib/hyperstart.sh
+++ b/hack/lib/hyperstart.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# A set of helpers for building hyperstart for tests
+
+hyper::hyperstart::build() {
+  if [ -e ${HYPERSTART_INITRD} ] && [ -e ${HYPERSTART_KERNEL} ]; then
+      echo "hypetstart initrd and kernel already exist, skip build"
+      return 0
+  fi
+  # build hyperstart
+  echo "clone hyperstart repo"
+  local tmp=$(mktemp -d)
+  git clone https://github.com/hyperhq/hyperstart ${tmp}/hyperstart
+  cd ${tmp}/hyperstart
+  echo "build hyperstart"
+  ./autogen.sh
+  ./configure
+  make
+
+  KERNEL_PATH="${tmp}/hyperstart/build/kernel"
+  if [ ! -f ${KERNEL_PATH} ]; then
+    return 1
+  fi
+  INITRD_PATH="${tmp}/hyperstart/build/hyper-initrd.img"
+  if [ ! -f ${INITRD_PATH} ]; then
+    return 1
+  fi
+
+  cp -v $KERNEL_PATH $HYPERSTART_KERNEL
+  cp -v $INITRD_PATH $HYPERSTART_INITRD
+
+  rm -rf "${HYPER_TEMP}/hyperstart"
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -7,13 +7,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# prepare kernel and initrd
-HYPERSTARTPATH="$GOPATH/src/github.com/hyperhq/hyperstart"
-RUNVPATH="$GOPATH/src/github.com/hyperhq/runv"
-cd $HYPERSTARTPATH && ./autogen.sh && ./configure && make
-cp -v $HYPERSTARTPATH/build/{kernel,hyper-initrd.img} $RUNVPATH/integration-test/test_data/
+source $(dirname "$0")/lib/ci-common.sh
 
 # do runv integration-test
-cd $RUNVPATH
+cd $RUNV_ROOT
 make test-integration
-


### PR DESCRIPTION
Ref: #462 
Now this test patch can basically run, Anyone want to test in your local environment, please follow the rules:
```
*PREPARE*
1. build and install runv to `/usr/local/bin/runv`
2. run `hack/ci-setup.sh` to setup necessary environment and tools.
*RUN TEST*
1. run `hack/functional-test.sh` to run test case 
```

While there is still some issues in runv that makes most cases failed, I'll open an issue(#481) to track them.

Signed-off-by: Crazykev <crazykev@zju.edu.cn>