### PR TITLE
*: Replace start with run and fix the description of run command

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ After creating a spec for your root filesystem, you can execute a container
 in your shell by running:
 
     # cd /mycontainer
-    # runv start start [ -b bundle ] <container-id>
+    # runv run [ -b bundle ] <container-id>
 
 If not specified, the default value for the 'bundle' is the current directory.
 'Bundle' is the directory where '` + specConfig + `' must be located.`

--- a/run.go
+++ b/run.go
@@ -12,7 +12,7 @@ var runCommand = cli.Command{
 Where "<container-id>" is your name for the instance of the container that you
 are running. The name you provide for the container instance must be unique on
 your host.`,
-	Description: `The create command creates an instance of a container for a bundle. The bundle
+	Description: `The run command creates and starts an instance of a container for a bundle. The bundle
 is a directory with a specification file named "` + specConfig + `" and a root
 filesystem.
 


### PR DESCRIPTION
start subcommand does not have "-b" flag. And it reads `state.json`, not `config.json`. It seems to be a mistake.

Signed-off-by: Ce Gao <ce.gao@outlook.com>