### PR TITLE
interface additions: kill -a flag, ps command, pause & resume

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,6 +159,8 @@ func main() {
 		stateCommand,
 		manageCommand,
 		shimCommand,
+		pauseCommand,
+		resumeCommand,
 		containerd.ContainerdCommand,
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/main.go
+++ b/main.go
@@ -152,6 +152,7 @@ func main() {
 		execCommand,
 		killCommand,
 		listCommand,
+		psCommand,
 		runCommand,
 		specCommand,
 		startCommand,

--- a/pause.go
+++ b/pause.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/hyperhq/runv/containerd/api/grpc/types"
+	"github.com/hyperhq/runv/lib/linuxsignal"
+	"github.com/urfave/cli"
+	netcontext "golang.org/x/net/context"
+)
+
+var pauseCommand = cli.Command{
+	Name:      "pause",
+	Usage:     "suspend all processes in the container",
+	ArgsUsage: `<container-id>`,
+	Action: func(context *cli.Context) error {
+		container := context.Args().First()
+		if container == "" {
+			return cli.NewExitError(fmt.Sprintf("container id cannot be empty"), -1)
+		}
+
+		c, err := getClient(filepath.Join(context.GlobalString("root"), container, "namespace/namespaced.sock"))
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("failed to get client: %v", err), -1)
+		}
+
+		plist, err := getProcessList(c, container)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("can't get process list, %v", err), -1)
+		}
+
+		for _, p := range plist {
+			if _, err := c.Signal(netcontext.Background(), &types.SignalRequest{
+				Id:     container,
+				Pid:    p,
+				Signal: uint32(linuxsignal.SIGSTOP),
+			}); err != nil {
+				return cli.NewExitError(fmt.Sprintf("suspend signal failed, %v", err), -1)
+			}
+		}
+
+		return nil
+	},
+}
+
+var resumeCommand = cli.Command{
+	Name:      "resume",
+	Usage:     "resume all processes in the container",
+	ArgsUsage: `<container-id>`,
+	Action: func(context *cli.Context) error {
+		container := context.Args().First()
+		if container == "" {
+			return cli.NewExitError(fmt.Sprintf("container id cannot be empty"), -1)
+		}
+
+		c, err := getClient(filepath.Join(context.GlobalString("root"), container, "namespace/namespaced.sock"))
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("failed to get client: %v", err), -1)
+		}
+
+		plist, err := getProcessList(c, container)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("can't get process list, %v", err), -1)
+		}
+
+		for _, p := range plist {
+			if _, err := c.Signal(netcontext.Background(), &types.SignalRequest{
+				Id:     container,
+				Pid:    p,
+				Signal: uint32(linuxsignal.SIGCONT),
+			}); err != nil {
+				return cli.NewExitError(fmt.Sprintf("resume signal failed, %v", err), -1)
+			}
+		}
+
+		return nil
+	},
+}

--- a/ps.go
+++ b/ps.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/hyperhq/runv/containerd/api/grpc/types"
+	"github.com/urfave/cli"
+	netcontext "golang.org/x/net/context"
+)
+
+var psCommand = cli.Command{
+	Name:      "ps",
+	Usage:     "ps displays the processes running inside a container",
+	ArgsUsage: `<container-id> [ps options]`, Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "format, f",
+			Value: "table",
+			Usage: `select one of: ` + formatOptions,
+		},
+	},
+	Action: func(context *cli.Context) error {
+		container := context.Args().First()
+		if container == "" {
+			return cli.NewExitError("container id cannot be empty", -1)
+		}
+		c, err := getContainerApi(context, container)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("can't access container, %v", err), -1)
+		}
+
+		switch context.String("format") {
+		case "table":
+			w := tabwriter.NewWriter(os.Stdout, 12, 1, 3, ' ', 0)
+			fmt.Fprint(w, "PROCESS\tCMD\n")
+			// we are limited by the containerd interface for now
+			for _, p := range c.Processes {
+				fmt.Fprintf(w, "%s\t%s\n",
+					p.Pid,
+					p.Args)
+			}
+			if err := w.Flush(); err != nil {
+				fatal(err)
+			}
+		case "json":
+			pids := make([]string, 0)
+			for _, p := range c.Processes {
+				pids = append(pids, p.Pid)
+			}
+
+			data, err := json.Marshal(pids)
+			if err != nil {
+				fatal(err)
+			}
+			os.Stdout.Write(data)
+			return nil
+		default:
+			return cli.NewExitError(fmt.Sprintf("invalid format option"), -1)
+		}
+
+		return nil
+	},
+}
+
+func getContainerApi(context *cli.Context, container string) (*types.Container, error) {
+	api, err := getClient(filepath.Join(context.GlobalString("root"), container, "namespace/namespaced.sock"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client: %v", err)
+	}
+
+	s, err := api.State(netcontext.Background(), &types.StateRequest{Id: container})
+	if err != nil {
+		return nil, fmt.Errorf("get container state failed, %v", err)
+	}
+
+	for _, c := range s.Containers {
+		if c.Id == container {
+			return c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("container %s not found", container)
+}

--- a/supervisor/process.go
+++ b/supervisor/process.go
@@ -93,8 +93,7 @@ func (p *Process) signal(sig int) error {
 		// TODO: change vm.KillContainer()
 		return p.ownerCont.ownerPod.vm.KillContainer(p.ownerCont.Id, syscall.Signal(sig))
 	} else {
-		// TODO support it
-		return fmt.Errorf("Kill to non-init process of container is unsupported")
+		return p.ownerCont.ownerPod.vm.SignalProcess(p.ownerCont.Id, p.Id, syscall.Signal(sig))
 	}
 }
 


### PR DESCRIPTION
These two patches add two runc features to runv; the --all flag to kill, and the PS command. Implementing these interfaces, reveals some limitations with the current design.

Runv currently implements the OCI interface by wrapping runv-containerd calls, so we are limited by the containerd interface as supported by runv at the moment.
This introduces some limitations on these implementations, which to resolve would require the refactoring or runv, which IMHO should be discussed.

First, the processes runv is aware of from each container is limited to only the processes started directly from runv (via run and exec). Children are not being tracked. An extension in hyperstart would be needed to overcome this limitation (to always fetch the process list dynamically).

Additionally, runv-containerd reports only limited information about the processes running inside the container. We can not show the PID for example. I'm not sure whether extending hyperstart to provide this info is enough, as we need to consider how it will affect runv-containerd. Even then, we will be limited by the current fields in the containerd API. In any case runv-containerd and the runv OCI interface need to be considered at the same time to improve upon this point.