### PR TITLE
Ensure the vm is running when vm operations are called

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -70,7 +70,7 @@ type VmContext struct {
 
 	logPrefix string
 
-	lock      sync.Mutex //protect update of context
+	lock      sync.RWMutex //protect update of context
 	idLock    sync.Mutex
 	pauseLock sync.Mutex
 	closeOnce sync.Once
@@ -157,8 +157,8 @@ func InitContext(id string, hub chan VmEvent, client chan *types.VmResponse, dc 
 // no handler associated with the context. VmEvent handling happens in a
 // separate goroutine, so this is thread-safe and asynchronous.
 func (ctx *VmContext) SendVmEvent(ev VmEvent) error {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
+	ctx.lock.RLock()
+	defer ctx.lock.RUnlock()
 
 	if ctx.handler == nil {
 		return fmt.Errorf("VmContext(%s): event handler already shutdown.", ctx.Id)
@@ -202,8 +202,8 @@ func (ctx *VmContext) NextPciAddr() int {
 }
 
 func (ctx *VmContext) LookupExecBySession(session uint64) string {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
+	ctx.lock.RLock()
+	defer ctx.lock.RUnlock()
 
 	for id, exec := range ctx.vmExec {
 		if exec.Process.Stdio == session {
@@ -223,8 +223,8 @@ func (ctx *VmContext) DeleteExec(id string) {
 }
 
 func (ctx *VmContext) LookupBySession(session uint64) string {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
+	ctx.lock.RLock()
+	defer ctx.lock.RUnlock()
 
 	for id, c := range ctx.containers {
 		if c.process.Stdio == session {
@@ -281,6 +281,14 @@ func (ctx *VmContext) Become(handler stateHandler, desc string) {
 	ctx.Log(DEBUG, "state change from %s to '%s'", orig, desc)
 }
 
+func (ctx *VmContext) IsRunning() bool {
+	var running bool
+	ctx.lock.RLock()
+	running = ctx.current == StateRunning
+	ctx.lock.RUnlock()
+	return running
+}
+
 // User API
 func (ctx *VmContext) SetNetworkEnvironment(net *api.SandboxConfig) {
 	ctx.lock.Lock()
@@ -298,12 +306,22 @@ func (ctx *VmContext) AddInterface(inf *api.InterfaceDescription, result chan ap
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "add interface %s during %v", inf.Id, ctx.current)
+		result <- NewNotReadyError(ctx.Id)
+	}
+
 	ctx.networks.addInterface(inf, result)
 }
 
 func (ctx *VmContext) RemoveInterface(id string, result chan api.Result) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
+
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "remove interface %s during %v", id, ctx.current)
+		result <- api.NewResultBase(id, true, "pod not running")
+	}
 
 	ctx.networks.removeInterface(id, result)
 }
@@ -327,6 +345,11 @@ func (ctx *VmContext) validateContainer(c *api.ContainerDescription) error {
 func (ctx *VmContext) AddContainer(c *api.ContainerDescription, result chan api.Result) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
+
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "add container %s during %v", c.Id, ctx.current)
+		result <- NewNotReadyError(ctx.Id)
+	}
 
 	if ctx.LogLevel(TRACE) {
 		ctx.Log(TRACE, "add container %#v", c)
@@ -393,6 +416,11 @@ func (ctx *VmContext) RemoveContainer(id string, result chan<- api.Result) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "remove container %s during %v", id, ctx.current)
+		result <- api.NewResultBase(id, true, "pod not running")
+	}
+
 	cc, ok := ctx.containers[id]
 	if !ok {
 		ctx.Log(WARNING, "container %s not exist", id)
@@ -417,6 +445,11 @@ func (ctx *VmContext) AddVolume(vol *api.VolumeDescription, result chan api.Resu
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "add volume %s during %v", vol.Name, ctx.current)
+		result <- NewNotReadyError(ctx.Id)
+	}
+
 	if _, ok := ctx.volumes[vol.Name]; ok {
 		estr := fmt.Sprintf("duplicate volume %s", vol.Name)
 		ctx.Log(WARNING, estr)
@@ -440,6 +473,11 @@ func (ctx *VmContext) AddVolume(vol *api.VolumeDescription, result chan api.Resu
 func (ctx *VmContext) RemoveVolume(name string, result chan<- api.Result) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
+
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "remove container %s during %v", name, ctx.current)
+		result <- api.NewResultBase(name, true, "pod not running")
+	}
 
 	disk, ok := ctx.volumes[name]
 	if !ok {

--- a/hypervisor/vm_states.go
+++ b/hypervisor/vm_states.go
@@ -30,6 +30,11 @@ func (ctx *VmContext) newContainer(id string) error {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "start container %s during %v", id, ctx.current)
+		return NewNotReadyError(ctx.Id)
+	}
+
 	c, ok := ctx.containers[id]
 	if ok {
 		ctx.Log(TRACE, "start sending INIT_NEWCONTAINER")
@@ -48,6 +53,12 @@ func (ctx *VmContext) newContainer(id string) error {
 func (ctx *VmContext) restoreContainer(id string) (alive bool, err error) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
+
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "start container %s during %v", id, ctx.current)
+		return false, NewNotReadyError(ctx.Id)
+	}
+
 	c, ok := ctx.containers[id]
 	if !ok {
 		return false, fmt.Errorf("try to associate a container not exist in sandbox")
@@ -76,6 +87,11 @@ func (ctx *VmContext) updateInterface(id string) error {
 func (ctx *VmContext) attachCmd(cmd *AttachCommand) error {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
+
+	if ctx.current != StateRunning {
+		ctx.Log(DEBUG, "attach container %s during %v", cmd.Container, ctx.current)
+		return NewNotReadyError(ctx.Id)
+	}
 
 	c, ok := ctx.containers[cmd.Container]
 	if !ok {


### PR DESCRIPTION
part of the fix of hyperhq/hyperd#598 (pod creation rollback), changes include:

- change context lock from Mutex to RWMutex
- move ctx.current access inside lock
- ensure vm operations has the running status check

Signed-off-by: Wang Xu <gnawux@gmail.com>