### PR TITLE
unify guest time keeping

### DIFF
--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -372,6 +372,27 @@ type qemucmd struct {
 	Value string `xml:"value,attr"`
 }
 
+type clock struct {
+	Offset string  `xml:"offset,attr"`
+	Timer  []timer `xml:"timer,omitempty"`
+}
+
+type timer struct {
+	Name       string  `xml:"name,attr"`
+	Track      string  `xml:"track,attr,omitempty"`
+	Tickpolicy string  `xml:"tickpolicy,attr,omitempty"`
+	CatchUp    catchup `xml:"catchup,omitempty"`
+	Frequency  uint32  `xml:"frequency,attr,omitempty"`
+	Mode       string  `xml:"mode,attr,omitempty"`
+	Present    string  `xml:"present,attr,omitempty"`
+}
+
+type catchup struct {
+	Threshold uint `xml:"threshold,attr,omitempty"`
+	Slew      uint `xml:"slew,attr,omitempty"`
+	Limit     uint `xml:"limit,attr,omitempty"`
+}
+
 type commandlines struct {
 	Cmds []qemucmd `xml:"qemu:arg"`
 }
@@ -392,6 +413,7 @@ type domain struct {
 	OnCrash     string       `xml:"on_crash"`
 	Devices     device       `xml:"devices"`
 	SecLabel    seclab       `xml:"seclabel"`
+	Clock       clock        `xml:"clock"`
 	CommandLine commandlines `xml:"qemu:commandline"`
 }
 
@@ -479,6 +501,9 @@ func (lc *LibvirtContext) domainXml(ctx *hypervisor.VmContext) (string, error) {
 	dom.OnPowerOff = "destroy"
 	dom.OnReboot = "destroy"
 	dom.OnCrash = "destroy"
+
+	dom.Clock.Offset = "utc"
+	dom.Clock.Timer = append(dom.Clock.Timer, timer{Name: "rtc", Track: "guest", Tickpolicy: "catchup"})
 
 	pcicontroller := controller{
 		Type:  "pci",

--- a/hypervisor/qemu/qemu_amd64.go
+++ b/hypervisor/qemu/qemu_amd64.go
@@ -63,7 +63,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 
 	params = append(params,
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults", "-no-hpet",
-		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams)
 
 	if boot.BootToBeTemplate || boot.BootFromTemplate {

--- a/hypervisor/qemu/qemu_arm64.go
+++ b/hypervisor/qemu/qemu_arm64.go
@@ -84,7 +84,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 	return append(params,
 		"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyAMA0 panic=1",
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults",
-		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams,
 		"-device", "pci-bridge,chassis_nr=1,id=pci.0",
 		"-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName), "-serial", fmt.Sprintf("unix:%s,server,nowait", ctx.ConsoleSockName),

--- a/hypervisor/qemu/qemu_ppc64le.go
+++ b/hypervisor/qemu/qemu_ppc64le.go
@@ -45,7 +45,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 		"-machine", "pseries,accel=kvm,usb=off", "-global", "kvm-pit.lost_tick_policy=discard", "-cpu", "host",
 		"-kernel", boot.Kernel, "-initrd", boot.Initrd,
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults",
-		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams,
 		"-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName), "-serial", fmt.Sprintf("unix:%s,server,nowait", ctx.ConsoleSockName),
 		"-device", "virtio-serial-pci,id=virtio-serial0,bus=pci.0,addr=0x2", "-device", "virtio-scsi-pci,id=scsi0,bus=pci.0,addr=0x3",

--- a/hypervisor/qemu/qemu_s390x.go
+++ b/hypervisor/qemu/qemu_s390x.go
@@ -39,7 +39,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 		"-kernel", boot.Kernel, "-initrd", boot.Initrd,
 		"-append", "\"console=ttyS1 panic=1 no_timer_check\"",
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults", "-enable-kvm",
-		"-rtc", "base=utc,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams,
 		"-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName),
 		"-chardev", fmt.Sprintf("socket,id=charconsole0,path=%s,server,nowait", ctx.ConsoleSockName),


### PR DESCRIPTION
Use `-rtc base=utc,clock=vm,driftfix=slew` for both libvirt and qemu driver.