### PR TITLE
use acpi_pm as guest clocksource when kvm is not supported

### DIFF
--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -448,6 +448,7 @@ func (lc *LibvirtContext) domainXml(ctx *hypervisor.VmContext) (string, error) {
 	dom.SecLabel.Type = "none"
 
 	dom.CPU.Mode = "host-passthrough"
+	cmdline := "console=ttyS0 panic=1 no_timer_check"
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		dom.Type = "qemu"
 		dom.CPU.Mode = "host-model"
@@ -456,6 +457,7 @@ func (lc *LibvirtContext) domainXml(ctx *hypervisor.VmContext) (string, error) {
 			Fallback: "allow",
 			Content:  "core2duo",
 		}
+		cmdline += " clocksource=acpi_pm notsc"
 	}
 
 	if ctx.Boot.HotAddCpuMem {
@@ -626,7 +628,7 @@ func (lc *LibvirtContext) domainXml(ctx *hypervisor.VmContext) (string, error) {
 	} else {
 		dom.OS.Kernel = boot.Kernel
 		dom.OS.Initrd = boot.Initrd
-		dom.OS.Cmdline = "console=ttyS0 panic=1 no_timer_check"
+		dom.OS.Cmdline = cmdline
 	}
 
 	data, err := xml.Marshal(dom)

--- a/hypervisor/qemu/qemu_amd64.go
+++ b/hypervisor/qemu/qemu_amd64.go
@@ -38,11 +38,13 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 		cpuParams = strconv.Itoa(boot.CPU)
 	}
 
+	cmdline := "console=ttyS0 panic=1 no_timer_check"
 	params := []string{
 		"-machine", machineClass + ",accel=kvm,usb=off", "-global", "kvm-pit.lost_tick_policy=discard", "-cpu", "host"}
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		glog.V(1).Info("kvm not exist change to no kvm mode")
 		params = []string{"-machine", machineClass + ",usb=off", "-cpu", "core2duo"}
+		cmdline += " clocksource=acpi_pm notsc"
 	}
 
 	if boot.Bios != "" && boot.Cbfs != "" {
@@ -52,13 +54,13 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 	} else if boot.Bios != "" {
 		params = append(params,
 			"-bios", boot.Bios,
-			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyS0 panic=1 no_timer_check")
+			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", cmdline)
 	} else if boot.Cbfs != "" {
 		params = append(params,
 			"-drive", fmt.Sprintf("if=pflash,file=%s,readonly=on", boot.Cbfs))
 	} else {
 		params = append(params,
-			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyS0 panic=1 no_timer_check")
+			"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", cmdline)
 	}
 
 	params = append(params,


### PR DESCRIPTION
The TSC does not run at a precisely specified rate, so the guest operating system has to measure its rate at boot time, and this measurement is always somewhat inaccurate. The ACPI PM timer does run at a precisely specified rate but is slower to read than the TSC.