### PR TITLE
clean up BlockdevInsertedEvent

### DIFF
--- a/hypervisor/events.go
+++ b/hypervisor/events.go
@@ -50,10 +50,7 @@ type VolumeUnmounted struct {
 }
 
 type BlockdevInsertedEvent struct {
-	Name       string
-	SourceType string //image or volume
 	DeviceName string
-	ScsiId     int
 	ScsiAddr   string // pass scsi addr to hyperstart
 }
 

--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -907,9 +907,6 @@ func scsiId2Addr(id int) (int, int, error) {
 }
 
 func (lc *LibvirtContext) AddDisk(ctx *hypervisor.VmContext, sourceType string, blockInfo *hypervisor.DiskDescriptor, result chan<- hypervisor.VmEvent) {
-	name := blockInfo.Name
-	id := blockInfo.ScsiId
-
 	if lc.domain == nil {
 		glog.Error("Cannot find domain")
 		result <- &hypervisor.DeviceFailed{
@@ -945,12 +942,9 @@ func (lc *LibvirtContext) AddDisk(ctx *hypervisor.VmContext, sourceType string, 
 		}
 		return
 	}
-	target, unit, err := scsiId2Addr(id)
+	target, unit, err := scsiId2Addr(blockInfo.ScsiId)
 	result <- &hypervisor.BlockdevInsertedEvent{
-		Name:       name,
-		SourceType: sourceType,
-		DeviceName: scsiId2Name(id),
-		ScsiId:     id,
+		DeviceName: scsiId2Name(blockInfo.ScsiId),
 		ScsiAddr:   fmt.Sprintf("%d:%d", target, unit),
 	}
 }

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -222,7 +222,6 @@ func (qc *QemuContext) Pause(ctx *hypervisor.VmContext, pause bool) error {
 }
 
 func (qc *QemuContext) AddDisk(ctx *hypervisor.VmContext, sourceType string, blockInfo *hypervisor.DiskDescriptor, result chan<- hypervisor.VmEvent) {
-	name := blockInfo.Name
 	filename := blockInfo.Filename
 	format := blockInfo.Format
 	id := blockInfo.ScsiId
@@ -247,7 +246,7 @@ func (qc *QemuContext) AddDisk(ctx *hypervisor.VmContext, sourceType string, blo
 		}
 	}
 
-	newDiskAddSession(ctx, qc, name, sourceType, filename, format, id, result)
+	newDiskAddSession(ctx, qc, filename, format, id, result)
 }
 
 func (qc *QemuContext) RemoveDisk(ctx *hypervisor.VmContext, blockInfo *hypervisor.DiskDescriptor, callback hypervisor.VmEvent, result chan<- hypervisor.VmEvent) {

--- a/hypervisor/qemu/qmp_test.go
+++ b/hypervisor/qemu/qmp_test.go
@@ -2,10 +2,11 @@ package qemu
 
 import (
 	"encoding/json"
-	"github.com/hyperhq/runv/hypervisor"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/hyperhq/runv/hypervisor"
 )
 
 func TestMessageParse(t *testing.T) {
@@ -261,7 +262,7 @@ func TestQmpDiskSession(t *testing.T) {
 	}
 
 	info := msg.(*hypervisor.BlockdevInsertedEvent)
-	t.Log("got block device", info.Name, info.SourceType, info.DeviceName)
+	t.Log("got block device", info.DeviceName)
 }
 
 func TestQmpFailOnce(t *testing.T) {
@@ -306,7 +307,7 @@ func TestQmpFailOnce(t *testing.T) {
 	}
 
 	info := msg.(*hypervisor.BlockdevInsertedEvent)
-	t.Log("got block device", info.Name, info.SourceType, info.DeviceName)
+	t.Log("got block device", info.DeviceName)
 }
 
 func TestQmpKeepFail(t *testing.T) {

--- a/hypervisor/qemu/qmp_wrapper.go
+++ b/hypervisor/qemu/qmp_wrapper.go
@@ -33,7 +33,7 @@ func defaultRespond(result chan<- hypervisor.VmEvent, callback hypervisor.VmEven
 	}
 }
 
-func newDiskAddSession(ctx *hypervisor.VmContext, qc *QemuContext, name, sourceType, filename, format string, id int, result chan<- hypervisor.VmEvent) {
+func newDiskAddSession(ctx *hypervisor.VmContext, qc *QemuContext, filename, format string, id int, result chan<- hypervisor.VmEvent) {
 	commands := make([]*QmpCommand, 2)
 	commands[0] = &QmpCommand{
 		Execute: "human-monitor-command",
@@ -53,10 +53,7 @@ func newDiskAddSession(ctx *hypervisor.VmContext, qc *QemuContext, name, sourceT
 	qc.qmp <- &QmpSession{
 		commands: commands,
 		respond: defaultRespond(result, &hypervisor.BlockdevInsertedEvent{
-			Name:       name,
-			SourceType: sourceType,
 			DeviceName: devName,
-			ScsiId:     id,
 		}),
 	}
 }

--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -279,10 +279,7 @@ func (vc *VBoxContext) AddDisk(ctx *hypervisor.VmContext, sourceType string, blo
 	}
 	devName := scsiId2Name(id)
 	callback := &hypervisor.BlockdevInsertedEvent{
-		Name:       name,
-		SourceType: sourceType,
 		DeviceName: devName,
-		ScsiId:     id,
 	}
 
 	glog.V(1).Infof("Disk %s (%s) add succeeded", name, filename)
@@ -461,10 +458,7 @@ func (vc *VBoxContext) LazyAddDisk(ctx *hypervisor.VmContext, name, sourceType, 
 	}
 	devName := scsiId2Name(id)
 	callback := &hypervisor.BlockdevInsertedEvent{
-		Name:       name,
-		SourceType: sourceType,
 		DeviceName: devName,
-		ScsiId:     id,
 	}
 	vc.mediums = append(vc.mediums, medium)
 	vc.callbacks = append(vc.callbacks, callback)


### PR DESCRIPTION
name, source type and scsiId are all set and passed by callers. It does
not make sense to simply pass them back.