### PR TITLE
Add symbol link vm root in container root dir

### DIFF
--- a/supervisor/container.go
+++ b/supervisor/container.go
@@ -157,6 +157,13 @@ func (c *Container) create() error {
 		return err
 	}
 
+	// Create vm root dir symbol link in container root dir
+	vmRootLinkPath := filepath.Join(stateDir, "vm-root")
+	vmRootPath := filepath.Join(hypervisor.BaseDir, c.ownerPod.vm.Id)
+	if err := os.Symlink(vmRootPath, vmRootLinkPath); err != nil {
+		return fmt.Errorf("failed to create symbol link %q: %v", vmRootLinkPath, err)
+	}
+
 	err = execPrestartHooks(c.Spec, state)
 	if err != nil {
 		glog.V(1).Infof("execute Prestart hooks failed, %s\n", err.Error())


### PR DESCRIPTION
for #472 
```
root@CK:/run/runv/test-vm# ls
namespace  state.json  vm-root
root@CK:/run/runv/test-vm# cd vm-root
root@CK:/run/runv/test-vm/vm-root# ls
console.sock  hyper.sock  pidfile  qmp.sock  share_dir  tty.sock
```
/cc @laijs 

Signed-off-by: Crazykev <crazykev@zju.edu.cn>