### PR TITLE
use hypervisor.BootConfig for factories' arguements

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -104,8 +104,8 @@ var ContainerdCommand = cli.Command{
 			f.Close()
 
 			if (driver != "" && driver != tconfig.Driver) ||
-				(kernel != "" && kernel != tconfig.Kernel) ||
-				(initrd != "" && initrd != tconfig.Initrd) {
+				(kernel != "" && kernel != tconfig.Config.Kernel) ||
+				(initrd != "" && initrd != tconfig.Config.Initrd) {
 				glog.Warningf("template config is not match the driver, kernel or initrd argument, disable template")
 				template = ""
 			} else if driver == "" {
@@ -127,7 +127,12 @@ var ContainerdCommand = cli.Command{
 		if template != "" {
 			f = singlefactory.New(templatefactory.NewFromExisted(tconfig))
 		} else {
-			f = factory.NewFromConfigs(kernel, initrd, vsock, nil)
+			bootConfig := hypervisor.BootConfig{
+				Kernel:      kernel,
+				Initrd:      initrd,
+				EnableVsock: vsock,
+			}
+			f = singlefactory.Dummy(bootConfig)
 		}
 		sv, err := supervisor.New(stateDir, containerdDir, f,
 			context.GlobalInt("default_cpus"), context.GlobalInt("default_memory"))

--- a/factory/direct/direct.go
+++ b/factory/direct/direct.go
@@ -10,14 +10,7 @@ type directFactory struct {
 	config hypervisor.BootConfig
 }
 
-func New(cpu, mem int, kernel, initrd string, vsock bool) base.Factory {
-	b := hypervisor.BootConfig{
-		CPU:         cpu,
-		Memory:      mem,
-		EnableVsock: vsock,
-		Kernel:      kernel,
-		Initrd:      initrd,
-	}
+func New(b hypervisor.BootConfig) base.Factory {
 	return &directFactory{config: b}
 }
 

--- a/factory/multi/multi.go
+++ b/factory/multi/multi.go
@@ -17,7 +17,8 @@ func (f Factory) GetVm(cpu, mem int) (*hypervisor.Vm, error) {
 			return single.New(b).GetVm(cpu, mem)
 		}
 	}
-	return single.New(f[0]).GetVm(cpu, mem)
+	boot := *f[0].Config()
+	return single.Dummy(boot).GetVm(cpu, mem)
 }
 
 func (f Factory) CloseFactory() {

--- a/factory/single/single.go
+++ b/factory/single/single.go
@@ -16,15 +16,8 @@ func (f Factory) GetVm(cpu, mem int) (*hypervisor.Vm, error) {
 	// check if match the base
 	config := f.Config()
 	if config.CPU > cpu || config.Memory > mem {
-		// also strip unrelated option from @config
-		boot := &hypervisor.BootConfig{
-			CPU:         cpu,
-			Memory:      mem,
-			Kernel:      config.Kernel,
-			Initrd:      config.Initrd,
-			EnableVsock: config.EnableVsock,
-		}
-		return hypervisor.GetVm("", boot, false)
+		boot := *config
+		return Dummy(boot).GetVm(cpu, mem)
 	}
 
 	vm, err := f.GetBaseVm()
@@ -59,3 +52,13 @@ func (f Factory) GetVm(cpu, mem int) (*hypervisor.Vm, error) {
 	}
 	return vm, err
 }
+
+type Dummy hypervisor.BootConfig
+
+func (f Dummy) GetVm(cpu, mem int) (*hypervisor.Vm, error) {
+	config := hypervisor.BootConfig(f)
+	config.CPU = cpu
+	config.Memory = mem
+	return hypervisor.GetVm("", &config, false)
+}
+func (f Dummy) CloseFactory() {}

--- a/factory/template/template.go
+++ b/factory/template/template.go
@@ -17,7 +17,7 @@ type templateFactory struct {
 	s *template.TemplateVmConfig
 }
 
-func New(templateRoot string, cpu, mem int, kernel, initrd string, vsock bool) base.Factory {
+func New(templateRoot string, b hypervisor.BootConfig) base.Factory {
 	var vmName string
 
 	for {
@@ -26,11 +26,11 @@ func New(templateRoot string, cpu, mem int, kernel, initrd string, vsock bool) b
 			break
 		}
 	}
-	s, err := template.CreateTemplateVM(filepath.Join(templateRoot, vmName), vmName, cpu, mem, kernel, initrd, vsock)
+	s, err := template.CreateTemplateVM(filepath.Join(templateRoot, vmName), vmName, b)
 	if err != nil {
 		glog.Errorf("failed to create template factory: %v", err)
 		glog.V(3).Infof("use direct factory instead")
-		return direct.New(cpu, mem, kernel, initrd, vsock)
+		return direct.New(b)
 	}
 	return &templateFactory{s: s}
 }

--- a/manage.go
+++ b/manage.go
@@ -80,7 +80,14 @@ var createTemplateCommand = cli.Command{
 			os.Exit(-1)
 		}
 
-		if _, err := templatecore.CreateTemplateVM(template, "", context.Int("cpu"), context.Int("mem"), kernel, initrd, context.GlobalBool("vsock")); err != nil {
+		boot := hypervisor.BootConfig{
+			CPU:         context.Int("cpu"),
+			Memory:      context.Int("mem"),
+			Kernel:      kernel,
+			Initrd:      initrd,
+			EnableVsock: context.GlobalBool("vsock"),
+		}
+		if _, err := templatecore.CreateTemplateVM(template, "", boot); err != nil {
 			fmt.Printf("Failed to create the template: %v\n", err)
 			os.Exit(-1)
 		}


### PR DESCRIPTION
make it easier to pass pc-lite, dax, tempalte, vsocks
configurations to the hypervisor driver(qemu/libvirt...).

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>