### PR TITLE
Show nslistener pid for `ps` command

### DIFF
--- a/ps.go
+++ b/ps.go
@@ -46,9 +46,9 @@ var psCommand = cli.Command{
 				fatal(err)
 			}
 		case "json":
-			pids := make([]string, 0)
+			pids := make([]int, 0)
 			for _, p := range c.Processes {
-				pids = append(pids, p.Pid)
+				pids = append(pids, int(p.SystemPid))
 			}
 
 			data, err := json.Marshal(pids)


### PR DESCRIPTION
We need to display nslistener pid for `ps` command to make `docker top`
work with runv container

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>