### PR TITLE
Join shim into nslistener network ns and end pod support

### DIFF
--- a/containerd/api/grpc/server/server.go
+++ b/containerd/api/grpc/server/server.go
@@ -232,6 +232,7 @@ func supervisorContainer2ApiContainer(c *supervisor.Container) *types.Container 
 		BundlePath: c.BundlePath,
 		Status:     "running",
 		Runtime:    "runv",
+		Labels:     []string{fmt.Sprintf("nslistener=%d", c.Processes["init"].ProcId)},
 	}
 }
 

--- a/create.go
+++ b/create.go
@@ -432,7 +432,9 @@ func findSharedContainer(root, nsPath string) (container string, err error) {
 			shimPidFile := filepath.Join(absRoot, item.Name(), "shim-init.pid")
 			spidByte, err := ioutil.ReadFile(shimPidFile)
 			if err != nil {
-				return "", fmt.Errorf("failed to read shim pid file %q: %v", shimPidFile, err)
+				// for backward compatibility, if dir doesn't contain "shim-init.pid"
+				// it could be old legacy dir, ignore and skip it.
+				continue
 			}
 			spid := strings.TrimSpace(string(spidByte))
 			if pid == spid {

--- a/exec.go
+++ b/exec.go
@@ -208,7 +208,7 @@ func runProcess(context *cli.Context, container string, config *specs.Process) (
 		monitorTtySize(c, container, process)
 	}
 
-	err = ociCreate(context, container, process, func(stdin, stdout, stderr string) error {
+	err = ociCreate(context, container, process, func(stdin, stdout, stderr string) (int, error) {
 		p := &types.AddProcessRequest{
 			Id:       container,
 			Pid:      process,
@@ -225,9 +225,9 @@ func runProcess(context *cli.Context, container string, config *specs.Process) (
 			Stderr: stderr,
 		}
 		if _, err := c.AddProcess(netcontext.Background(), p); err != nil {
-			return err
+			return -1, err
 		}
-		return nil
+		return -1, nil
 	})
 	if err != nil {
 		return -1, err

--- a/list.go
+++ b/list.go
@@ -50,7 +50,7 @@ in json format:
 		},
 	},
 	Action: func(context *cli.Context) {
-		s, err := getContainers(context)
+		s, err := getContainers(context.GlobalString("root"))
 		if err != nil {
 			fatal(err)
 		}
@@ -91,8 +91,7 @@ in json format:
 	},
 }
 
-func getContainers(context *cli.Context) ([]containerState, error) {
-	root := context.GlobalString("root")
+func getContainers(root string) ([]containerState, error) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return nil, err

--- a/nsenter/namespace.h
+++ b/nsenter/namespace.h
@@ -1,0 +1,14 @@
+#ifndef NSENTER_NAMESPACE_H
+#define NSENTER_NAMESPACE_H
+
+#ifndef _GNU_SOURCE
+#	define _GNU_SOURCE
+#endif
+#include <sched.h>
+
+/* All of these are taken from include/uapi/linux/sched.h */
+#ifndef CLONE_NEWNET
+#	define CLONE_NEWNET 0x40000000 /* New network namespace */
+#endif
+
+#endif /* NSENTER_NAMESPACE_H */

--- a/nsenter/nsenter.go
+++ b/nsenter/nsenter.go
@@ -1,0 +1,12 @@
+// +build linux,!gccgo
+
+package nsenter
+
+/*
+#cgo CFLAGS: -Wall
+extern void nsexec();
+void __attribute__((constructor)) init(void) {
+	nsexec();
+}
+*/
+import "C"

--- a/nsenter/nsenter_gccgo.go
+++ b/nsenter/nsenter_gccgo.go
@@ -1,0 +1,25 @@
+// +build linux,gccgo
+
+package nsenter
+
+/*
+#cgo CFLAGS: -Wall
+extern void nsexec();
+void __attribute__((constructor)) init(void) {
+	nsexec();
+}
+*/
+import "C"
+
+// AlwaysFalse is here to stay false
+// (and be exported so the compiler doesn't optimize out its reference)
+var AlwaysFalse bool
+
+func init() {
+	if AlwaysFalse {
+		// by referencing this C init() in a noop test, it will ensure the compiler
+		// links in the C function.
+		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65134
+		C.init()
+	}
+}

--- a/nsenter/nsenter_unsupported.go
+++ b/nsenter/nsenter_unsupported.go
@@ -1,0 +1,5 @@
+// +build !linux !cgo
+
+package nsenter
+
+import "C"

--- a/nsenter/nsexec.c
+++ b/nsenter/nsexec.c
@@ -1,0 +1,54 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+/* Get all of the CLONE_NEW* flags. */
+#include "namespace.h"
+
+#define bail(fmt, ...)								\
+	do {									\
+		int ret = __COUNTER__ + 1;					\
+		fprintf(stderr, "nsenter: " fmt ": %m\n", ##__VA_ARGS__);	\
+		exit(ret);							\
+	} while(0)
+
+static int getNslistenerPid(void)
+{
+	int pid;
+	char *nspidStr, *endptr;
+
+	nspidStr = getenv("_NSLISTENERPID");
+	if (nspidStr== NULL || *nspidStr == '\0')
+		return -1;
+
+	pid = strtol(nspidStr, &endptr, 10);
+	if (*endptr != '\0')
+		bail("unable to parse _NSLISTENERPID");
+
+	return pid;
+}
+
+void nsexec(void)
+{
+	int nsPid, nsFd;
+	char *path;
+
+	nsPid = getNslistenerPid();
+	if (nsPid <= 0) {
+		return;
+	}
+
+	path = malloc(sizeof(char)*64);
+	sprintf(path, "/proc/%d/ns/net", nsPid);
+	nsFd = open(path, O_RDONLY);
+	setns(nsFd, CLONE_NEWNET);
+
+	free(path);
+	close(nsFd);
+	return;
+}

--- a/spec.go
+++ b/spec.go
@@ -103,3 +103,23 @@ func loadSpec(ocffile string) (*specs.Spec, error) {
 	}
 	return &spec, nil
 }
+
+func updateSpec(spec *specs.Spec, ocffile string) error {
+	if _, err := os.Stat(ocffile); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%q doesn't exists", ocffile)
+		}
+		return fmt.Errorf("Stat %q error: %v", ocffile, err)
+	}
+
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return fmt.Errorf("failed to marshal spec file during update: %v", err)
+	}
+
+	if err = ioutil.WriteFile(ocffile, data, 0640); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
runv shim should share same network namespace with nslistener, then if
user try to insert an network interface into runv shim's netns,
nslistener can observe the changes and copy the configure into VM.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>