### PR TITLE
Track container status, and add delete command to OCI interface

### DIFF
--- a/containerd/api/grpc/server/server.go
+++ b/containerd/api/grpc/server/server.go
@@ -230,7 +230,7 @@ func supervisorContainer2ApiContainer(c *supervisor.Container) *types.Container 
 	return &types.Container{
 		Id:         c.Id,
 		BundlePath: c.BundlePath,
-		Status:     "running",
+		Status:     c.Status,
 		Runtime:    "runv",
 	}
 }

--- a/containerd/api/grpc/server/server.go
+++ b/containerd/api/grpc/server/server.go
@@ -147,7 +147,17 @@ func (s *apiServer) State(ctx context.Context, r *types.StateRequest) (*types.St
 }
 
 func (s *apiServer) UpdateContainer(ctx context.Context, r *types.UpdateContainerRequest) (*types.UpdateContainerResponse, error) {
-	return nil, errors.New("UpdateContainer() not implemented yet")
+	glog.V(3).Infof("gRPC handle UpdateContainer")
+
+	if r.Status != supervisor.ContainerStateDeleted {
+		return nil, fmt.Errorf("UpdateContainer() status %s not supported", r.Status)
+	}
+
+	err := s.sv.DeleteContainer(r.Id)
+	if err != nil {
+		return nil, err
+	}
+	return &types.UpdateContainerResponse{}, nil
 }
 
 func (s *apiServer) UpdateProcess(ctx context.Context, r *types.UpdateProcessRequest) (*types.UpdateProcessResponse, error) {

--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -189,9 +189,9 @@ func namespaceShare(sv *supervisor.Supervisor, namespace, state string) {
 	events := sv.Events.Events(time.Time{})
 	containerCount := 0
 	for e := range events {
-		if e.Type == supervisor.EventContainerStart {
+		if e.Type == supervisor.EventContainerCreate {
 			containerCount++
-		} else if e.Type == supervisor.EventExit && e.PID == "init" {
+		} else if e.Type == supervisor.EventContainerDelete {
 			containerCount--
 			if containerCount == 0 {
 				syscall.Kill(0, syscall.SIGQUIT)

--- a/delete.go
+++ b/delete.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hyperhq/runv/containerd/api/grpc/types"
+	"github.com/hyperhq/runv/supervisor"
+	"github.com/urfave/cli"
+	netcontext "golang.org/x/net/context"
+)
+
+var deleteCommand = cli.Command{
+	Name:      "delete",
+	Usage:     "delete a stopped container",
+	ArgsUsage: `<container-id>`,
+	Action: func(context *cli.Context) error {
+		container := context.Args().First()
+		if container == "" {
+			return cli.NewExitError("container id cannot be empty", -1)
+		}
+
+		containerPath := filepath.Join(context.GlobalString("root"), container)
+
+		if dir, err := os.Stat(containerPath); err != nil || !dir.IsDir() {
+			return fmt.Errorf("container %s does not exist", container)
+		}
+
+		api, err := getClient(filepath.Join(containerPath, "namespace/namespaced.sock"))
+		if err != nil {
+			return fmt.Errorf("failed to get client: %v", err)
+		}
+
+		_, err = api.GetServerVersion(netcontext.Background(), nil)
+		if err != nil {
+			// if we can't connect to the api, runv was killed before it could clean up the stopped containers
+			err := os.RemoveAll(containerPath)
+			if err != nil {
+				return fmt.Errorf("delete stale container %s failed, %v", container, err)
+			}
+			return nil
+		}
+
+		_, err = api.UpdateContainer(netcontext.Background(), &types.UpdateContainerRequest{Id: container, Status: supervisor.ContainerStateDeleted})
+		if err != nil {
+			return fmt.Errorf("delete container %s failed, %v", container, err)
+		}
+
+		return nil
+	},
+}

--- a/integration-test/kill_test.go
+++ b/integration-test/kill_test.go
@@ -35,9 +35,9 @@ func (s *RunVSuite) TestKillKILL(c *check.C) {
 
 	timeout := true
 	for count := 0; count < 10; count++ {
-		out, exitCode := s.runvCommand(c, "list")
+		out, exitCode := s.runvCommand(c, "state", ctrName)
 		c.Assert(exitCode, checker.Equals, 0)
-		if !strings.Contains(out, ctrName) {
+		if !strings.Contains(out, "running") {
 			timeout = false
 			break
 		}

--- a/main.go
+++ b/main.go
@@ -162,6 +162,7 @@ func main() {
 		pauseCommand,
 		resumeCommand,
 		containerd.ContainerdCommand,
+		deleteCommand,
 	}
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)

--- a/supervisor/container.go
+++ b/supervisor/container.go
@@ -26,6 +26,7 @@ const (
 	ContainerStateCreated  = "created"
 	ContainerStateRunning  = "running"
 	ContainerStateStopped  = "stopped"
+	ContainerStateDeleted  = "deleted" // special state that will lead to deleting the container resources
 )
 
 type Container struct {

--- a/supervisor/events.go
+++ b/supervisor/events.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	EventExit           = "exit"
-	EventContainerStart = "start-container"
-	EventProcessStart   = "start-process"
+	EventExit            = "exit"
+	EventContainerCreate = "create-container"
+	EventContainerStart  = "start-container"
+	EventContainerDelete = "delete-container"
+	EventProcessStart    = "start-process"
 )
 
 var (


### PR DESCRIPTION
This PR implements the delete command as defined by the OCI spec.

To properly separate the container stopped state, from a deleted (non existent state) we add the necessary container states to runv.