### PR TITLE
support kvmtool for runv

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 The current release of `runV` supports the following hypervisors:
 - KVM (QEMU 2.0 or later)
+- KVM (Kvmtool)
 - Xen (4.5 or later)
 - VirtualBox (Mac OS X)
 

--- a/driverloader/driverloader_linux.go
+++ b/driverloader/driverloader_linux.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/hyperhq/runv/hypervisor"
+	"github.com/hyperhq/runv/hypervisor/kvmtool"
 	"github.com/hyperhq/runv/hypervisor/libvirt"
 	"github.com/hyperhq/runv/hypervisor/qemu"
 	"github.com/hyperhq/runv/hypervisor/xen"
@@ -52,6 +53,12 @@ func Probe(driver string) (hd hypervisor.HypervisorDriver, err error) {
 		if qd != nil {
 			glog.V(1).Infof("Driver \"qemu\" loaded")
 			return qd, nil
+		}
+	case "kvmtool":
+		kd := kvmtool.InitDriver()
+		if kd != nil {
+			glog.V(1).Infof("Driver \"kvmtool\" loaded")
+			return kd, nil
 		}
 	}
 

--- a/hyperstart/api/json/constants.go
+++ b/hyperstart/api/json/constants.go
@@ -36,3 +36,5 @@ const HYPERSTART_EXEC_CONTAINER = "hyperstart"
 
 const HYPER_VSOCK_CTL_PORT = 2718
 const HYPER_VSOCK_MSG_PORT = 2719
+
+const HYPER_USE_SERIAL = "hyper_use_serial"

--- a/hypervisor/kvmtool/lkvm.go
+++ b/hypervisor/kvmtool/lkvm.go
@@ -1,0 +1,456 @@
+// +build linux
+
+package kvmtool
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/golang/glog"
+	"github.com/hyperhq/runv/hyperstart/api/json"
+	"github.com/hyperhq/runv/hypervisor"
+	"github.com/hyperhq/runv/hypervisor/network"
+	"github.com/hyperhq/runv/hypervisor/types"
+	"github.com/hyperhq/runv/lib/term"
+	"github.com/hyperhq/runv/lib/utils"
+)
+
+const (
+	KVMTOOL_EXEC = "lkvm"
+)
+
+//implement the hypervisor.HypervisorDriver interface
+type KvmtoolDriver struct {
+	executable string
+}
+
+//implement the hypervisor.DriverContext interface
+type KvmtoolContext struct {
+	driver *KvmtoolDriver
+}
+
+func InitDriver() *KvmtoolDriver {
+	cmd, err := exec.LookPath(KVMTOOL_EXEC)
+	if err != nil {
+		return nil
+	}
+
+	return &KvmtoolDriver{
+		executable: cmd,
+	}
+}
+
+func (kd *KvmtoolDriver) Name() string {
+	return "kvmtool"
+}
+
+func (kd *KvmtoolDriver) InitContext(homeDir string) hypervisor.DriverContext {
+	return &KvmtoolContext{
+		driver: kd,
+	}
+}
+
+func (kd *KvmtoolDriver) LoadContext(persisted map[string]interface{}) (hypervisor.DriverContext, error) {
+	return &KvmtoolContext{
+		driver: kd,
+	}, nil
+}
+
+func (kd *KvmtoolDriver) SupportLazyMode() bool {
+	return false
+}
+
+func (kd *KvmtoolDriver) SupportVmSocket() bool {
+	return false
+}
+
+func arguments(ctx *hypervisor.VmContext) []string {
+	boot := ctx.Boot
+	memParams := strconv.Itoa(boot.Memory)
+	cpuParams := strconv.Itoa(boot.CPU)
+
+	// kvmtool enforce uses ttyS0 as console,
+	// hyperstart can only use ttyS1 and ttyS2 as ctl and tty channel.
+	args := []string{
+		"run", "-k", boot.Kernel, "-i", boot.Initrd, "-m", memParams,
+		"-c", cpuParams, "--name", ctx.Id}
+	//use ttyS0 as kernel console
+	args = append(args, "-p", "console=ttyS0 "+json.HYPER_USE_SERIAL)
+
+	// kvmtool enforce uses ttyS0 as console,
+	// hyperstart can only use ttyS1 and ttyS2 as ctl and tty channel.
+	args = append(args, "--tty", "0", "--tty", "1", "--tty", "2")
+
+	// attach nic at the start since kvmtool doesn't support hotplug
+	args = append(args, "--network", "mode=tap,tapif="+nicTapName(ctx.Id))
+
+	// arch specified
+	if arch_args := arch_arguments(); arch_args != nil {
+		args = append(args, arch_args...)
+	}
+
+	// pass ShareDir as rootfs directroy to prevent lkvm share host rootfs with vm
+	args = append(args, "-d", ctx.ShareDir)
+
+	// why setup ShareDir as 9p directroy? the 9ptag of rootfs is set to "/dev/root" bydefault
+	args = append(args, "--9p", ctx.ShareDir+","+hypervisor.ShareDirTag)
+
+	return args
+}
+
+func nicTapName(id string) string {
+	str := strings.Split(id, "-")
+	if len(str) != 2 {
+		return id
+	}
+	return str[1]
+}
+
+func (kc *KvmtoolContext) Launch(ctx *hypervisor.VmContext) {
+	var (
+		ptmx    *os.File     = nil
+		slaver  *os.File     = nil
+		err     error        = nil
+		conSock net.Listener = nil
+		ctlSock net.Listener = nil
+		ttySock net.Listener = nil
+	)
+
+	defer func() {
+		if err != nil {
+			if ptmx != nil {
+				ctx.Log(hypervisor.INFO, "close ptmx")
+				ptmx.Close()
+			}
+
+			if slaver != nil {
+				ctx.Log(hypervisor.INFO, "close slaver")
+				slaver.Close()
+			}
+
+			if conSock != nil {
+				ctx.Log(hypervisor.INFO, "close conSock")
+				conSock.Close()
+			}
+
+			if ctlSock != nil {
+				ctx.Log(hypervisor.INFO, "close ctlSock")
+				ctlSock.Close()
+			}
+
+			if ttySock != nil {
+				ctx.Log(hypervisor.INFO, "close ttySock")
+				ttySock.Close()
+			}
+
+			ctx.Hub <- &hypervisor.VmStartFailEvent{
+				Message: fmt.Sprintf("fail to launch kvmtool: %s", err),
+			}
+		}
+	}()
+
+	if kc.driver.executable == "" {
+		err = fmt.Errorf("can not find kvmtool executable")
+		return
+	}
+
+	args := arguments(ctx)
+
+	cmd := exec.Command(kc.driver.executable, args...)
+
+	ptmx, err = os.OpenFile("/dev/ptmx", os.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		ctx.Log(hypervisor.ERROR, "fail to open /dev/ptmx: %v", err)
+		return
+	}
+
+	var num int = 0
+	_, _, ret := syscall.Syscall(syscall.SYS_IOCTL, uintptr(ptmx.Fd()),
+		syscall.TIOCGPTN, uintptr(unsafe.Pointer(&num)))
+	if ret != 0 {
+		err = fmt.Errorf("fail to ioctl /dev/ptmx: %v\n", ret)
+		return
+	}
+	pts := fmt.Sprintf("/dev/pts/%v", num)
+
+	num = 0
+	_, _, ret = syscall.Syscall(syscall.SYS_IOCTL, ptmx.Fd(),
+		syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&num)))
+
+	slaver, err = os.OpenFile(pts, os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		ctx.Log(hypervisor.ERROR, "fail to open %v: %v\n", pts, err)
+		return
+	}
+
+	cmd.Stdin = slaver
+	cmd.Stdout = slaver
+	cmd.Stderr = slaver
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
+	cmd.Env = []string{fmt.Sprintf("HOME=%s", hypervisor.BaseDir)}
+
+	err = cmd.Start()
+	if err != nil {
+		ctx.Log(hypervisor.ERROR, "fail to start kvmtool vm %v %v %v", kc.driver.executable, args, err)
+		return
+	}
+
+	go func() {
+		cmd.Wait()
+	}()
+
+	retry := 0
+	var output []byte
+	len := 0
+	for retry < 5 {
+		data := make([]byte, 128)
+		nr, err := ptmx.Read(data)
+		output = append(output, data[:nr]...)
+		len += nr
+		if nr > 0 {
+			conPty, ctlPty, ttyPty := lookupPtys(output[:len])
+			ctx.Log(hypervisor.INFO, "find %v %v %v", conPty, ctlPty, ttyPty)
+			if conPty != "" && ctlPty != "" && ttyPty != "" {
+				conSock, err = net.Listen("unix", ctx.ConsoleSockName)
+				if err != nil {
+					return
+				}
+
+				ctlSock, err = net.Listen("unix", ctx.HyperSockName)
+				if err != nil {
+					return
+				}
+				ttySock, err = net.Listen("unix", ctx.TtySockName)
+				if err != nil {
+					return
+				}
+
+				go sock2pty(conSock, conPty, false)
+				go sock2pty(ctlSock, ctlPty, true)
+				go sock2pty(ttySock, ttyPty, true)
+
+				go func() {
+					// without this, guest burst output will crash kvmtool, why?
+					slaver.Close()
+					for true {
+						nr, err := ptmx.Read(data)
+						if nr > 0 {
+							glog.Infof("lkvm output: %v", string(data[:nr]))
+						}
+						if err != nil {
+							glog.Infof("read lkvm output failed: %v", err)
+							break
+						}
+					}
+					ptmx.Close()
+				}()
+				return
+			}
+		}
+		time.Sleep(1 * time.Second)
+		retry++
+	}
+	//TODO: kill lkvm
+	err = fmt.Errorf("cannot find pts devices used by lkvm")
+}
+
+func sock2pty(ls net.Listener, ptypath string, input bool) {
+	defer ls.Close()
+
+	conn, err := ls.Accept()
+	if err != nil {
+		glog.Errorf("fail to accept client %v", err)
+		return
+	}
+	defer func() {
+		conn.Close()
+		glog.Infof("close socket to pty")
+	}()
+
+	pty, err := os.OpenFile(ptypath, os.O_RDWR|syscall.O_NOCTTY, 0600)
+	if err != nil {
+		glog.Errorf("fail to open %v, %v", ptypath, err)
+		return
+	}
+	defer pty.Close()
+
+	_, err = term.SetRawTerminal(pty.Fd())
+	if err != nil {
+		glog.Errorf("fail to setrowmode for %v: %v", ptypath, err)
+		return
+	}
+
+	wg := &sync.WaitGroup{}
+
+	copy := func(dst io.Writer, src io.Reader, input bool) {
+		// copy from io.Copy, kvmtool driver needs to pass the escape_char as normal char
+		buf := make([]byte, 32*1024)
+		for {
+			var newbuf []byte = nil
+			nr, er := src.Read(buf)
+			if nr > 0 {
+				if input {
+					newbuf = bytes.Replace(buf[:nr], []byte{1}, []byte{1, 1}, -1)
+					nr = len(newbuf)
+				} else {
+					newbuf = buf
+				}
+
+				nw, ew := dst.Write(newbuf[:nr])
+				if ew != nil {
+					glog.Infof("write failed: %v", ew)
+					break
+				}
+				if nr != nw {
+					glog.Infof("write != read")
+					break
+				}
+				continue
+			}
+			if er == io.EOF {
+				glog.Infof("read end of file")
+				break
+			}
+			if er != nil {
+				glog.Infof("read failed: %v", er)
+				break
+			}
+		}
+
+		wg.Done()
+		glog.Infof("REACH the END of io copy")
+	}
+
+	wg.Add(1)
+	go copy(conn, pty, false)
+
+	if input {
+		wg.Add(1)
+		go copy(pty, conn, true)
+	}
+
+	wg.Wait()
+}
+
+func ptySplit(r rune) bool {
+	return r == ' ' || r == '\n' || r == '\r'
+}
+
+func lookupPtys(data []byte) (string, string, string) {
+	con := ""
+	ctl := ""
+	tty := ""
+
+	fields := bytes.FieldsFunc(data, ptySplit)
+	for i, field := range fields {
+		if (string(field) == "pty") && (i < len(fields)-1) {
+			if con == "" {
+				con = string(fields[i+1])
+			} else if ctl == "" {
+				ctl = string(fields[i+1])
+			} else if tty == "" {
+				tty = string(fields[i+1])
+				break
+			}
+		}
+	}
+
+	return con, ctl, tty
+}
+
+func (kc *KvmtoolContext) Associate(ctx *hypervisor.VmContext) {
+
+}
+
+func (kc *KvmtoolContext) Dump() (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (kc *KvmtoolContext) Shutdown(ctx *hypervisor.VmContext) {
+	ctx.Log(hypervisor.INFO, "shutdown")
+	cmd := exec.Command(kc.driver.executable, []string{"stop", "-n", ctx.Id}...)
+	stdout := bytes.NewBuffer([]byte{})
+	stderr := bytes.NewBuffer([]byte{})
+
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Env = []string{fmt.Sprintf("HOME=%s", hypervisor.BaseDir)}
+
+	cmd.Run()
+}
+
+func (kc *KvmtoolContext) Kill(ctx *hypervisor.VmContext) {
+	kc.Shutdown(ctx)
+	ctx.Hub <- &hypervisor.VmKilledEvent{Success: true}
+}
+
+func (kc *KvmtoolContext) Stats(ctx *hypervisor.VmContext) (*types.PodStats, error) {
+	return nil, nil
+}
+
+func (kc *KvmtoolContext) Close() {
+
+}
+
+func (kc *KvmtoolContext) Pause(ctx *hypervisor.VmContext, pause bool) error {
+	err := fmt.Errorf("doesn't support pause for kvmtool right now")
+	ctx.Log(hypervisor.ERROR, "%v", err)
+	return err
+}
+
+func scsiId2Name(id int) string {
+	return "vd" + utils.DiskId2Name(id)
+}
+
+func (kc *KvmtoolContext) AddDisk(ctx *hypervisor.VmContext, sourceType string, blockInfo *hypervisor.DiskDescriptor, result chan<- hypervisor.VmEvent) {
+	result <- &hypervisor.BlockdevInsertedEvent{
+		DeviceName: scsiId2Name(blockInfo.ScsiId),
+	}
+
+	//TODO: mount block root device to sharedir
+}
+
+func (kc *KvmtoolContext) RemoveDisk(ctx *hypervisor.VmContext, blockInfo *hypervisor.DiskDescriptor, callback hypervisor.VmEvent, result chan<- hypervisor.VmEvent) {
+	ctx.Log(hypervisor.INFO, "RemoveDisk is unsupported on kvmtool driver")
+	result <- callback
+
+}
+
+func (kc *KvmtoolContext) AddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo, result chan<- hypervisor.VmEvent) {
+	ctx.Log(hypervisor.INFO, "Hotplug is unsupported on kvmtool...")
+	// Nic has already attached on lkvm vm, so only add this interface into bridge
+	network.UpAndAddToBridge(nicTapName(ctx.Id), host.Bridge)
+	result <- &hypervisor.NetDevInsertedEvent{
+		Id:         host.Id,
+		Index:      guest.Index,
+		DeviceName: guest.Device,
+		Address:    guest.Busaddr,
+	}
+}
+
+func (kc *KvmtoolContext) RemoveNic(ctx *hypervisor.VmContext, n *hypervisor.InterfaceCreated, callback hypervisor.VmEvent, result chan<- hypervisor.VmEvent) {
+	ctx.Log(hypervisor.INFO, "RemoveNic is unsupported on kvmtool driver")
+	result <- callback
+}
+
+func (kc *KvmtoolContext) SetCpus(ctx *hypervisor.VmContext, cpus int) error {
+	return fmt.Errorf("SetCpus is unsupported on kvmtool driver")
+}
+
+func (kc *KvmtoolContext) AddMem(ctx *hypervisor.VmContext, slot, size int) error {
+	return fmt.Errorf("AddMem is unsupported on kvmtool driver")
+}
+
+func (kc *KvmtoolContext) Save(ctx *hypervisor.VmContext, path string) error {
+	return fmt.Errorf("Save is unsupported on kvmtool driver")
+}

--- a/hypervisor/kvmtool/lkvm_amd64.go
+++ b/hypervisor/kvmtool/lkvm_amd64.go
@@ -1,0 +1,7 @@
+// +build linux,amd64
+
+package kvmtool
+
+func arch_arguments() []string {
+	return nil
+}

--- a/hypervisor/kvmtool/lkvm_arm64.go
+++ b/hypervisor/kvmtool/lkvm_arm64.go
@@ -1,0 +1,7 @@
+// +build linux,arm64
+
+package kvmtool
+
+func arch_arguments() []string {
+	return []string{"--irqchip", "gicv3"}
+}

--- a/hypervisor/kvmtool/network.go
+++ b/hypervisor/kvmtool/network.go
@@ -1,0 +1,28 @@
+// +build linux
+
+package kvmtool
+
+import (
+	"github.com/hyperhq/runv/api"
+	"github.com/hyperhq/runv/hypervisor/network"
+)
+
+func (kd *KvmtoolDriver) BuildinNetwork() bool {
+	/*
+		kvmtool doesn't support hot-add nic, so we have to start lkvm with
+		one nic attached and use kvmtool adjust network mode
+	*/
+	return true
+}
+
+func (kd *KvmtoolDriver) InitNetwork(bIface, bIP string, disableIptables bool) error {
+	return network.InitNetwork(bIface, bIP, disableIptables)
+}
+
+func (kc *KvmtoolContext) ConfigureNetwork(config *api.InterfaceDescription) (*network.Settings, error) {
+	return network.Configure(true, config)
+}
+
+func (kc *KvmtoolContext) ReleaseNetwork(releasedIP string) error {
+	return network.Release(releasedIP)
+}

--- a/hypervisor/network/network_linux.go
+++ b/hypervisor/network/network_linux.go
@@ -959,20 +959,23 @@ func ReleasePortMaps(containerip string, maps []*api.PortDescription) error {
 	return nil
 }
 
-func UpAndAddToBridge(name string) error {
+func UpAndAddToBridge(name, bridge string) error {
 	inf, err := net.InterfaceByName(name)
 	if err != nil {
 		glog.Error("cannot find network interface ", name)
 		return err
 	}
-	brg, err := net.InterfaceByName(BridgeIface)
+	if bridge == "" {
+		bridge = BridgeIface
+	}
+	brg, err := net.InterfaceByName(bridge)
 	if err != nil {
-		glog.Error("cannot find bridge interface ", BridgeIface)
+		glog.Error("cannot find bridge interface ", bridge)
 		return err
 	}
 	err = AddToBridge(inf, brg, "")
 	if err != nil {
-		glog.Errorf("cannot add %s to %s ", name, BridgeIface)
+		glog.Errorf("cannot add %s to %s ", name, bridge)
 		return err
 	}
 	err = NetworkLinkUp(inf)

--- a/hypervisor/xen/xen.go
+++ b/hypervisor/xen/xen.go
@@ -255,7 +255,7 @@ func (xc *XenContext) AddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNic
 
 				glog.V(1).Infof("nic %s insert succeeded", guest.Device)
 
-				err = network.UpAndAddToBridge(fmt.Sprintf("vif%d.%d", xc.domId, guest.Index))
+				err = network.UpAndAddToBridge(fmt.Sprintf("vif%d.%d", xc.domId, guest.Index), "")
 				if err != nil {
 					glog.Error("fail to add vif to bridge: ", err.Error())
 					ctx.Hub <- &hypervisor.DeviceFailed{


### PR DESCRIPTION
run with docker
./runv --debug --driver kvmtool --kernel /kernel --initrd /hyper-initrd.img  containerd
dockerd -D -l debug --containerd=/run/runv-containerd/containerd.sock --add-runtime runv=runv --default-runtime runv

or simply
./runv --debug --driver kvmtool --kernel /kernel --initrd /hyper-initrd.img --log_dir=/tmp/runvlog run ubuntu -b `pwd`

Signed-off-by: Gao feng <omarapazanadi@gmail.com>

There is a serial port related bug or shortage on arm kvmtool, runv works well with patched kvmtool.