### PR TITLE
use machine type pc

### DIFF
--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -442,7 +442,7 @@ func (lc *LibvirtContext) domainXml(ctx *hypervisor.VmContext) (string, error) {
 
 	dom.OS.Supported = "yes"
 	dom.OS.Type.Arch = "x86_64"
-	dom.OS.Type.Machine = "pc-i440fx-2.1"
+	dom.OS.Type.Machine = "pc"
 	dom.OS.Type.Content = "hvm"
 
 	dom.SecLabel.Type = "none"

--- a/hypervisor/qemu/qemu_amd64.go
+++ b/hypervisor/qemu/qemu_amd64.go
@@ -27,7 +27,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 	qc.cpus = boot.CPU
 
 	var machineClass, memParams, cpuParams string
-	machineClass = "pc-i440fx-2.1"
+	machineClass = "pc"
 	memParams = fmt.Sprintf("size=%d,slots=1,maxmem=%dM", boot.Memory, hypervisor.DefaultMaxMem) // TODO set maxmem to the total memory of the system
 	cpuParams = fmt.Sprintf("cpus=%d,maxcpus=%d", boot.CPU, hypervisor.DefaultMaxCpus)           // TODO set it to the cpus of the system
 


### PR DESCRIPTION
Qemu pc machine type is alias for the latest pc-i440fx-xxx series.
Use it so that we do not have to worry about updating it for different
qemu versions.