### PR TITLE
remove useless AllocateNetwork

### DIFF
--- a/hypervisor/driver.go
+++ b/hypervisor/driver.go
@@ -2,7 +2,6 @@ package hypervisor
 
 import (
 	"errors"
-	"os"
 
 	"github.com/hyperhq/runv/api"
 	"github.com/hyperhq/runv/hypervisor/network"
@@ -85,9 +84,8 @@ type DriverContext interface {
 
 	Pause(ctx *VmContext, pause bool) error
 
-	ConfigureNetwork(vmId, requestedIP string, config *api.InterfaceDescription) (*network.Settings, error)
-	AllocateNetwork(vmId, requestedIP string) (*network.Settings, error)
-	ReleaseNetwork(vmId, releasedIP string, file *os.File) error
+	ConfigureNetwork(config *api.InterfaceDescription) (*network.Settings, error)
+	ReleaseNetwork(releasedIP string) error
 
 	Stats(ctx *VmContext) (*types.PodStats, error)
 
@@ -167,15 +165,11 @@ func (ec *EmptyContext) Pause(ctx *VmContext, pause bool) error { return nil }
 
 func (ec *EmptyContext) BuildinNetwork() bool { return false }
 
-func (ec *EmptyContext) ConfigureNetwork(vmId, requestedIP string, config *api.InterfaceDescription) (*network.Settings, error) {
+func (ec *EmptyContext) ConfigureNetwork(config *api.InterfaceDescription) (*network.Settings, error) {
 	return nil, nil
 }
 
-func (ec *EmptyContext) AllocateNetwork(vmId, requestedIP string) (*network.Settings, error) {
-	return nil, nil
-}
-
-func (ec *EmptyContext) ReleaseNetwork(vmId, releasedIP string, file *os.File) error {
+func (ec *EmptyContext) ReleaseNetwork(releasedIP string) error {
 	return nil
 }
 

--- a/hypervisor/libvirt/network.go
+++ b/hypervisor/libvirt/network.go
@@ -3,8 +3,6 @@
 package libvirt
 
 import (
-	"os"
-
 	"github.com/hyperhq/runv/api"
 	"github.com/hyperhq/runv/hypervisor/network"
 )
@@ -17,14 +15,10 @@ func (ld *LibvirtDriver) InitNetwork(bIface, bIP string, disableIptables bool) e
 	return network.InitNetwork(bIface, bIP, disableIptables)
 }
 
-func (lc *LibvirtContext) ConfigureNetwork(vmId, requestedIP string, config *api.InterfaceDescription) (*network.Settings, error) {
-	return network.Configure(vmId, requestedIP, true, config)
+func (lc *LibvirtContext) ConfigureNetwork(config *api.InterfaceDescription) (*network.Settings, error) {
+	return network.Configure(true, config)
 }
 
-func (lc *LibvirtContext) AllocateNetwork(vmId, requestedIP string) (*network.Settings, error) {
-	return network.Allocate(vmId, requestedIP, true)
-}
-
-func (lc *LibvirtContext) ReleaseNetwork(vmId, releasedIP string, file *os.File) error {
-	return network.Release(vmId, releasedIP)
+func (lc *LibvirtContext) ReleaseNetwork(releasedIP string) error {
+	return network.Release(releasedIP)
 }

--- a/hypervisor/network.go
+++ b/hypervisor/network.go
@@ -225,9 +225,9 @@ func (nc *NetworkContext) configureInterface(index, pciAddr int, name string, in
 
 	if HDriver.BuildinNetwork() {
 		/* VBox doesn't support join to bridge */
-		settings, err = nc.sandbox.DCtx.ConfigureNetwork(nc.sandbox.Id, "", inf)
+		settings, err = nc.sandbox.DCtx.ConfigureNetwork(inf)
 	} else {
-		settings, err = network.Configure(nc.sandbox.Id, "", false, inf)
+		settings, err = network.Configure(false, inf)
 	}
 
 	if err != nil {

--- a/hypervisor/network/network_darwin.go
+++ b/hypervisor/network/network_darwin.go
@@ -11,16 +11,11 @@ func InitNetwork(bIface, bIP string, disableIptables bool) error {
 	return fmt.Errorf("Generial Network driver is unsupported on this os")
 }
 
-func Allocate(vmId, requestedIP string, addrOnly bool, maps []*api.PortDescription) (*Settings, error) {
-	return nil, fmt.Errorf("Generial Network driver is unsupported on this os")
-}
-
-func Configure(vmId, requestedIP string, addrOnly bool,
-	maps []*api.PortDescription, inf *api.InterfaceDescription) (*Settings, error) {
+func Configure(addrOnly bool, inf *api.InterfaceDescription) (*Settings, error) {
 	return nil, fmt.Errorf("Generial Network driver is unsupported on this os")
 }
 
 // Release an interface for a select ip
-func Release(vmId, releasedIP string, maps []*api.PortDescription, file *os.File) error {
+func Release(releasedIP string) error {
 	return fmt.Errorf("Generial Network driver is unsupported on this os")
 }

--- a/hypervisor/network/network_linux.go
+++ b/hypervisor/network/network_linux.go
@@ -1069,32 +1069,7 @@ func AllocateAddr(requestedIP string) (*Settings, error) {
 	}, nil
 }
 
-func Allocate(vmId, requestedIP string, addrOnly bool) (*Settings, error) {
-
-	setting, err := AllocateAddr(requestedIP)
-	if err != nil {
-		return nil, err
-	}
-
-	//TODO: will move to a dedicate method
-	//err = SetupPortMaps(ip.String(), maps)
-	//if err != nil {
-	//	glog.Errorf("Setup Port Map failed %s", err)
-	//	return nil, err
-	//}
-
-	device, tapFile, err := GetTapFd("", BridgeIface, "")
-	if err != nil {
-		IpAllocator.ReleaseIP(BridgeIPv4Net, net.ParseIP(setting.IPAddress))
-		return nil, err
-	}
-
-	setting.Device = device
-	setting.File = tapFile
-	return setting, nil
-}
-
-func Configure(vmId, requestedIP string, addrOnly bool, inf *api.InterfaceDescription) (*Settings, error) {
+func Configure(addrOnly bool, inf *api.InterfaceDescription) (*Settings, error) {
 
 	ip, mask, err := ipParser(inf.Ip)
 	if err != nil {
@@ -1166,7 +1141,7 @@ func ReleaseAddr(releasedIP string) error {
 }
 
 // Release an interface for a select ip
-func Release(vmId, releasedIP string) error {
+func Release(releasedIP string) error {
 
 	if err := ReleaseAddr(releasedIP); err != nil {
 		return err

--- a/hypervisor/network/network_unsupported.go
+++ b/hypervisor/network/network_unsupported.go
@@ -13,15 +13,10 @@ func InitNetwork(bIface, bIP string, disableIptables bool) error {
 	return nil
 }
 
-func Allocate(vmId, requestedIP string, addrOnly bool, maps []*api.PortDescription) (*Settings, error) {
-	return nil, nil
-}
-
-func Configure(vmId, requestedIP string, addrOnly bool,
-	maps []*api.PortDescription, inf *api.InterfaceDescription) (*Settings, error) {
+func Configure(addrOnly bool, inf *api.InterfaceDescription) (*Settings, error) {
 	return nil, fmt.Errorf("Generial Network driver is unsupported on this os")
 }
 
-func Release(vmId, releasedIP string, maps []*api.PortDescription, file *os.File) error {
+func Release(releasedIP string) error {
 	return nil
 }

--- a/hypervisor/qemu/network.go
+++ b/hypervisor/qemu/network.go
@@ -1,8 +1,6 @@
 package qemu
 
 import (
-	"os"
-
 	"github.com/hyperhq/runv/api"
 	"github.com/hyperhq/runv/hypervisor/network"
 )
@@ -15,14 +13,10 @@ func (qd *QemuDriver) InitNetwork(bIface, bIP string, disableIptables bool) erro
 	return nil
 }
 
-func (qc *QemuContext) ConfigureNetwork(vmId, requestedIP string, config *api.InterfaceDescription) (*network.Settings, error) {
+func (qc *QemuContext) ConfigureNetwork(config *api.InterfaceDescription) (*network.Settings, error) {
 	return nil, nil
 }
 
-func (qc *QemuContext) AllocateNetwork(vmId, requestedIP string) (*network.Settings, error) {
-	return nil, nil
-}
-
-func (qc *QemuContext) ReleaseNetwork(vmId, releasedIP string, file *os.File) error {
+func (qc *QemuContext) ReleaseNetwork(releasedIP string) error {
 	return nil
 }

--- a/hypervisor/vbox/network.go
+++ b/hypervisor/vbox/network.go
@@ -3,7 +3,6 @@ package vbox
 import (
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/golang/glog"
 	"github.com/hyperhq/runv/api"
@@ -61,33 +60,7 @@ func (vd *VBoxDriver) InitNetwork(bIface, bIP string, disableIptables bool) erro
 	return nil
 }
 
-func (vc *VBoxContext) AllocateNetwork(vmId, requestedIP string) (*network.Settings, error) {
-	ip, err := network.IpAllocator.RequestIP(network.BridgeIPv4Net, net.ParseIP(requestedIP))
-	if err != nil {
-		return nil, err
-	}
-
-	maskSize, _ := network.BridgeIPv4Net.Mask.Size()
-
-	//err = SetupPortMaps(vmId, ip.String(), maps)
-	//if err != nil {
-	//	glog.Errorf("Setup Port Map failed %s", err)
-	//	return nil, err
-	//}
-
-	return &network.Settings{
-		Mac:         "",
-		IPAddress:   ip.String(),
-		Gateway:     network.BridgeIPv4Net.IP.String(),
-		Bridge:      "",
-		IPPrefixLen: maskSize,
-		Device:      "",
-		File:        nil,
-	}, nil
-}
-
-func (vc *VBoxContext) ConfigureNetwork(vmId,
-	requestedIP string, config *api.InterfaceDescription) (*network.Settings, error) {
+func (vc *VBoxContext) ConfigureNetwork(config *api.InterfaceDescription) (*network.Settings, error) {
 	ip, ipnet, err := net.ParseCIDR(config.Ip)
 	if err != nil {
 		glog.Errorf("Parse interface IP failed %s", err)
@@ -95,12 +68,6 @@ func (vc *VBoxContext) ConfigureNetwork(vmId,
 	}
 
 	maskSize, _ := ipnet.Mask.Size()
-
-	//err = SetupPortMaps(vmId, ip.String(), maps)
-	//if err != nil {
-	//	glog.Errorf("Setup Port Map failed %s", err)
-	//	return nil, err
-	//}
 
 	return &network.Settings{
 		Mac:         config.Mac,
@@ -114,7 +81,7 @@ func (vc *VBoxContext) ConfigureNetwork(vmId,
 }
 
 // Release an interface for a select ip
-func (vc *VBoxContext) ReleaseNetwork(vmId, releasedIP string, file *os.File) error {
+func (vc *VBoxContext) ReleaseNetwork(releasedIP string) error {
 	if err := network.IpAllocator.ReleaseIP(network.BridgeIPv4Net, net.ParseIP(releasedIP)); err != nil {
 		return err
 	}

--- a/hypervisor/xen/network.go
+++ b/hypervisor/xen/network.go
@@ -3,8 +3,6 @@
 package xen
 
 import (
-	"os"
-
 	"github.com/hyperhq/runv/api"
 	"github.com/hyperhq/runv/hypervisor/network"
 )
@@ -17,14 +15,10 @@ func (xd *XenDriver) InitNetwork(bIface, bIP string, disableIptables bool) error
 	return nil
 }
 
-func (xc *XenContext) ConfigureNetwork(vmId, requestedIP string, config *api.InterfaceDescription) (*network.Settings, error) {
+func (xc *XenContext) ConfigureNetwork(config *api.InterfaceDescription) (*network.Settings, error) {
 	return nil, nil
 }
 
-func (xc *XenContext) AllocateNetwork(vmId, requestedIP string) (*network.Settings, error) {
-	return nil, nil
-}
-
-func (xc *XenContext) ReleaseNetwork(vmId, releasedIP string, file *os.File) error {
+func (xc *XenContext) ReleaseNetwork(releasedIP string) error {
 	return nil
 }


### PR DESCRIPTION
AllocateNetwork is replaced by ConfigureNetwork for a long time.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>