### PR TITLE
Fixes #527 that mistook "init" for process name

### DIFF
--- a/create.go
+++ b/create.go
@@ -245,7 +245,7 @@ func createContainer(context *cli.Context, container, namespace string, config *
 		return err
 	}
 
-	return ociCreate(context, container, func(stdin, stdout, stderr string) error {
+	return ociCreate(context, container, "init", func(stdin, stdout, stderr string) error {
 		r := &types.CreateContainerRequest{
 			Id:         container,
 			Runtime:    "runv-create",
@@ -269,7 +269,7 @@ func createContainer(context *cli.Context, container, namespace string, config *
 
 }
 
-func ociCreate(context *cli.Context, container string, createFunc func(stdin, stdout, stderr string) error) error {
+func ociCreate(context *cli.Context, container, process string, createFunc func(stdin, stdout, stderr string) error) error {
 	path, err := osext.Executable()
 	if err != nil {
 		return fmt.Errorf("cannot find self executable path for %s: %v\n", os.Args[0], err)
@@ -319,7 +319,7 @@ func ociCreate(context *cli.Context, container string, createFunc func(stdin, st
 		if context.GlobalBool("debug") {
 			args = append(args, "--debug")
 		}
-		args = append(args, "shim", "--container", container, "--process", "init")
+		args = append(args, "shim", "--container", container, "--process", process)
 		if context.String("pid-file") != "" {
 			args = append(args, "--proxy-exit-code", "--proxy-signal")
 		}

--- a/exec.go
+++ b/exec.go
@@ -208,7 +208,7 @@ func runProcess(context *cli.Context, container string, config *specs.Process) (
 		monitorTtySize(c, container, process)
 	}
 
-	err = ociCreate(context, container, func(stdin, stdout, stderr string) error {
+	err = ociCreate(context, container, process, func(stdin, stdout, stderr string) error {
 		p := &types.AddProcessRequest{
 			Id:       container,
 			Pid:      process,


### PR DESCRIPTION
Fixes #527 that mistook "init" for process name
to monitor in case of exec command, which makes
exec command whose process has exited stuck

Signed-off-by: frank yang <yyb196@gmail.com>