### PR TITLE
Fixes #520 #527

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -208,7 +208,7 @@ func runProcess(context *cli.Context, container string, config *specs.Process) (
 		monitorTtySize(c, container, process)
 	}
 
-	err = ociCreate(context, container, process, func(stdin, stdout, stderr string) error {
+	err = ociCreate(context, container, process, filepath.Join(context.GlobalString("root"), container, "namespace"), func(stdin, stdout, stderr string) error {
 		p := &types.AddProcessRequest{
 			Id:       container,
 			Pid:      process,


### PR DESCRIPTION
Fixes #520 #527
only assign pty path to one process named runv-shim whose lifecyle is same as the terminal.

After did a lot of tests in my environment, I found that if multiple processes
have opened the same pty, docker-containerd-shim wonn't get the close event
of pty and will get stucked on waiting streem terminate forever.

Because runv and runv-containerd don't have a controlling tty, when they
opening the pty, it will become their controlling tty automatically.
that's why it complained about "operation not permitted" in case which mentioned
in bug #520. AFAIK a pty can only become controlling tty of one process.

Signed-off-by: frank yang <yyb196@gmail.com>