### PR TITLE
fix send on closed channel

### DIFF
--- a/hypervisor/report.go
+++ b/hypervisor/report.go
@@ -52,6 +52,13 @@ func (ctx *VmContext) reportUnexpectedRequest(ev VmEvent, state string) {
 // reportVmFault send report to daemon, notify about that:
 //   1. vm op failed due to some reason described in `cause`
 func (ctx *VmContext) reportVmFault(cause string) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			ctx.Log(WARNING, "panic during send vm fault message to channel")
+		}
+	}()
+
 	ctx.client <- &types.VmResponse{
 		VmId:  ctx.Id,
 		Code:  types.E_FAILED,


### PR DESCRIPTION
fix https://github.com/hyperhq/hyperd/issues/653

2017/08/16 08:47:27 http: panic serving @: send on closed channel
goroutine 76 [running]:
net/http.(*conn).serve.func1(0xc42071a100)
/usr/local/go/src/net/http/server.go:1491 +0x12a
panic(0x1394c60, 0xc4210c39a0)
/usr/local/go/src/runtime/panic.go:458 +0x243
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*VmContext).startPod(0xc421077b80, 0xc4200b52c0, 0x6077bd)
/home/gaofeng/go/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/vm_states.go:225 +0x325
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*Vm).InitSandbox(0xc4207866e0, 0xc4200b52c0, 0xc420196580, 0x20)
/home/gaofeng/go/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/vm.go:231 +0x4b
github.com/hyperhq/hyperd/daemon/pod.(*XPod).createSandbox(0xc420196580, 0xc420779400, 0xc42062d640, 0xc420196580)

Signed-off-by: Gao feng <omarapazanadi@gmail.com>