### PR TITLE
maintain process info

### DIFF
--- a/cli/container.go
+++ b/cli/container.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -47,7 +48,8 @@ func startContainer(vm *hypervisor.Vm, root, container string, spec *specs.Spec,
 
 	// No need to load, container init process must be the first
 	var p []Process
-	p = append(p, Process{Id: "init", Pid: state.Pid, CreateTime: state.ShimCreateTime})
+	cmd := strings.Join(spec.Process.Args, " ")
+	p = append(p, Process{Id: "init", Pid: state.Pid, CMD: cmd, CreateTime: state.ShimCreateTime})
 	if err = pl.Save(p); err != nil {
 		return err
 	}
@@ -260,7 +262,8 @@ func addProcess(options runvOptions, vm *hypervisor.Vm, container, process strin
 		return nil, err
 	}
 	defer pl.Release()
-	err = pl.Add(Process{Id: process, Pid: shim.Pid, CreateTime: stat.StartTime})
+	cmd := strings.Join(spec.Args, " ")
+	err = pl.Add(Process{Id: process, Pid: shim.Pid, CMD: cmd, CreateTime: stat.StartTime})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -18,9 +18,10 @@ var (
 )
 
 const (
-	specConfig = "config.json"
-	stateJSON  = "state.json"
-	usage      = `Open Container Initiative hypervisor-based runtime
+	specConfig  = "config.json"
+	stateJSON   = "state.json"
+	processJSON = "process.json"
+	usage       = `Open Container Initiative hypervisor-based runtime
 
 runv is a command line client for running applications packaged according to
 the Open Container Format (OCF) and is a compliant implementation of the

--- a/cli/pause.go
+++ b/cli/pause.go
@@ -33,7 +33,7 @@ var pauseCommand = cli.Command{
 		}
 
 		for _, p := range plist {
-			if err := h.SignalProcess(container, p, linuxsignal.SIGSTOP); err != nil {
+			if err := h.SignalProcess(container, p.Id, linuxsignal.SIGSTOP); err != nil {
 				return cli.NewExitError(fmt.Sprintf("suspend signal failed, %v", err), -1)
 			}
 		}
@@ -66,7 +66,7 @@ var resumeCommand = cli.Command{
 		}
 
 		for _, p := range plist {
-			if err := h.SignalProcess(container, p, linuxsignal.SIGCONT); err != nil {
+			if err := h.SignalProcess(container, p.Id, linuxsignal.SIGCONT); err != nil {
 				return cli.NewExitError(fmt.Sprintf("resume signal failed, %v", err), -1)
 			}
 		}

--- a/cli/process.go
+++ b/cli/process.go
@@ -1,0 +1,82 @@
+// +build linux
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type Process struct {
+	// process id
+	Id string `json:"id"`
+	// process shim pid
+	Pid int `json:"pid"`
+	// process shim created time
+	CreateTime uint64 `json:"create_time"`
+}
+
+type ProcessList struct {
+	file *os.File
+}
+
+// Return locked processlist, which needs to be released by caller after using
+func NewProcessList(root, name string) (*ProcessList, error) {
+	f, err := os.OpenFile(filepath.Join(root, name, processJSON), os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = syscall.Flock(int(f.Fd()), syscall.LOCK_SH); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("Placing LOCK_SH lock on process json file failed: %s", err.Error())
+	}
+
+	return &ProcessList{file: f}, nil
+}
+
+func (pl *ProcessList) Release() {
+	syscall.Flock(int(pl.file.Fd()), syscall.LOCK_UN)
+	pl.file.Close()
+	pl.file = nil
+}
+
+func (pl *ProcessList) Load() ([]Process, error) {
+	var p []Process
+	if err := json.NewDecoder(pl.file).Decode(&p); err != nil {
+		return nil, fmt.Errorf("Decode process json file failed: %s", err.Error())
+	}
+
+	return p, nil
+}
+
+func (pl *ProcessList) Save(p []Process) error {
+	// upgrade SH lock to EX lock
+	err := syscall.Flock(int(pl.file.Fd()), syscall.LOCK_EX)
+	if err != nil {
+		return fmt.Errorf("Placing LOCK_EX on process json file failed: %s", err.Error())
+	}
+
+	data, err := json.MarshalIndent(p, "", "\t")
+	if err != nil {
+		return err
+	}
+	if _, err = pl.file.Write(data); err != nil {
+		return fmt.Errorf("Saving process json file failed: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (pl *ProcessList) Add(p Process) error {
+	list, err := pl.Load()
+	if err != nil {
+		return err
+	}
+
+	list = append(list, p)
+	return pl.Save(list)
+}

--- a/cli/process.go
+++ b/cli/process.go
@@ -15,6 +15,8 @@ type Process struct {
 	Id string `json:"id"`
 	// process shim pid
 	Pid int `json:"pid"`
+	// Process command line
+	CMD string `json:"cmd"`
 	// process shim created time
 	CreateTime uint64 `json:"create_time"`
 }

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -45,8 +45,6 @@ var psCommand = cli.Command{
 				fatal(err)
 			}
 		case "json":
-			pids := make([]string, 0)
-
 			data, err := json.Marshal(pids)
 			if err != nil {
 				fatal(err)

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -39,7 +39,7 @@ var psCommand = cli.Command{
 			for _, p := range plist {
 				fmt.Fprintf(w, "%d\t%s\n",
 					p.Pid,
-					"todo process.Args")
+					p.CMD)
 			}
 			if err := w.Flush(); err != nil {
 				fatal(err)

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -27,7 +27,7 @@ var psCommand = cli.Command{
 		if container == "" {
 			return cli.NewExitError("container id cannot be empty", -1)
 		}
-		pids, err := getProcessList(context, container)
+		plist, err := getProcessList(context, container)
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("can't access container, %v", err), -1)
 		}
@@ -36,15 +36,19 @@ var psCommand = cli.Command{
 		case "table":
 			w := tabwriter.NewWriter(os.Stdout, 12, 1, 3, ' ', 0)
 			fmt.Fprint(w, "PROCESS\tCMD\n")
-			for _, p := range pids {
-				fmt.Fprintf(w, "%s\t%s\n",
-					p,
+			for _, p := range plist {
+				fmt.Fprintf(w, "%d\t%s\n",
+					p.Pid,
 					"todo process.Args")
 			}
 			if err := w.Flush(); err != nil {
 				fatal(err)
 			}
 		case "json":
+			var pids []int
+			for _, p := range plist {
+				pids = append(pids, p.Pid)
+			}
 			data, err := json.Marshal(pids)
 			if err != nil {
 				fatal(err)


### PR DESCRIPTION
Save all process info in process.json file in container root directory. With it, `runv  ps` can look up and verify each of them.

```
[root@hypervsock foobar]# cat process.json
[
        {
                "id": "init",
                "pid": 66524,
                "cmd": "sh",
                "create_time": 10904725
        }
]
```

With it, `runv ps` works and containerd is able to interpret its result properly.
```
[hypervsock@containerd]$sudo runv --root /run/containerd/runc/default ps foobar
PROCESS     CMD
70492       sh
70559       top
[hypervsock@containerd]$sudo runv --root /run/containerd/runc/default ps foobar -f json
[70492,70559]
[hypervsock@containerd]$sudo ctr t ps foobar
PID
70492
70559
````
