### PR TITLE
update runv state to match OCI definition

### DIFF
--- a/cli/state.go
+++ b/cli/state.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/urfave/cli"
@@ -25,13 +24,11 @@ type cState struct {
 	// InitProcessPid is the init process id in the parent namespace
 	InitProcessPid int `json:"pid"`
 	// Bundle is the path on the filesystem to the bundle
-	Bundle string `json:"bundlePath"`
-	// Rootfs is a path to a directory containing the container's root filesystem.
-	Rootfs string `json:"rootfsPath"`
+	Bundle string `json:"bundle"`
 	// Status is the current status of the container, running, paused, ...
 	Status string `json:"status"`
-	// Created is the unix timestamp for the creation time of the container in UTC
-	Created time.Time `json:"created"`
+	// Annotations contains the list of annotations associated with the container
+	Annotations map[string]string `json:"annotations"`
 }
 
 var stateCommand = cli.Command{
@@ -100,8 +97,7 @@ func getContainer(context *cli.Context, name string) (*cState, error) {
 		InitProcessPid: state.Pid,
 		Status:         status,
 		Bundle:         state.Bundle,
-		Rootfs:         filepath.Join(state.Bundle, "rootfs"),
-		Created:        time.Unix(state.ContainerCreateTime, 0),
 	}
+
 	return s, nil
 }

--- a/integration-test/state_test.go
+++ b/integration-test/state_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -18,13 +17,11 @@ type cState struct {
 	// InitProcessPid is the init process id in the parent namespace
 	InitProcessPid int `json:"pid"`
 	// Bundle is the path on the filesystem to the bundle
-	Bundle string `json:"bundlePath"`
-	// Rootfs is a path to a directory containing the container's root filesystem.
-	Rootfs string `json:"rootfsPath"`
+	Bundle string `json:"bundle"`
 	// Status is the current status of the container, running, paused, ...
 	Status string `json:"status"`
-	// Created is the unix timestamp for the creation time of the container in UTC
-	Created time.Time `json:"created"`
+	// Annotations contains the list of annotations associated with the container
+	Annotations map[string]string `json:"annotations"`
 }
 
 func (s *RunVSuite) TestStateSleep(c *check.C) {
@@ -63,7 +60,7 @@ func (s *RunVSuite) TestStateSleep(c *check.C) {
 	c.Assert(cs.ID, check.Equals, ctrName)
 	c.Assert(cs.InitProcessPid, checker.Not(checker.Equals), 0)
 	c.Assert(cs.Bundle, checker.Equals, s.bundlePath)
-	c.Assert(cs.Rootfs, checker.Equals, filepath.Join(s.bundlePath, spec.Root.Path))
 	c.Assert(cs.Status, checker.Equals, "running")
+	c.Assert(cs.Annotations, checker.IsNil)
 	<-exitChan
 }


### PR DESCRIPTION
Per
https://github.com/opencontainers/runtime-spec/blob/master/runtime.md,
`runv state` should return something like:

```
{
    "ociVersion": "0.2.0",
    "id": "oci-container1",
    "status": "running",
    "pid": 4422,
    "bundle": "/containers/redis",
    "annotations": {
        "myKey": "myValue"
    }
}
```

So we return:
```
$sudo runv --root /run/containerd/runc/default state foobar
{
  "ociVersion": "1.0.0",
  "id": "foobar",
  "pid": 95193,
  "bundle": "/run/containerd/io.containerd.runtime.v1.linux/default/foobar",
  "status": "running",
  "annotations": null
}
```