### PR TITLE
add owner field to list and state cmd

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -13,6 +13,7 @@ import (
 )
 
 const formatOptions = `table or json`
+const defaultOwner = "root"
 
 // containerState represents the platform agnostic pieces relating to a
 // running container's status and state
@@ -67,14 +68,15 @@ in json format:
 		switch context.String("format") {
 		case "", "table":
 			w := tabwriter.NewWriter(os.Stdout, 12, 1, 3, ' ', 0)
-			fmt.Fprint(w, "ID\tPID\tSTATUS\tBUNDLE\tCREATED\n")
+			fmt.Fprint(w, "ID\tPID\tSTATUS\tBUNDLE\tCREATED\tOWNER\n")
 			for _, item := range s {
-				fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\n",
+				fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\n",
 					item.ID,
 					item.InitProcessPid,
 					item.Status,
 					item.Bundle,
-					item.Created.Format(time.RFC3339Nano))
+					item.Created.Format(time.RFC3339Nano),
+					defaultOwner)
 			}
 			if err := w.Flush(); err != nil {
 				fatal(err)

--- a/cli/main.go
+++ b/cli/main.go
@@ -146,6 +146,9 @@ func main() {
 	if err := app.Run(os.Args); err != nil {
 		glog.Errorf("app.Run(os.Args) failed with err: %#v", err)
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		cli.HandleExitCoder(err)
+		// non-standard errors
+		os.Exit(22)
 	}
 }
 

--- a/cli/ps.go
+++ b/cli/ps.go
@@ -12,7 +12,7 @@ import (
 var psCommand = cli.Command{
 	Name:      "ps",
 	Usage:     "ps displays the processes running inside a container",
-	ArgsUsage: `<container-id> [ps options]`, Flags: []cli.Flag{
+	ArgsUsage: `<container-id>`, Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "format, f",
 			Value: "table",

--- a/cli/state.go
+++ b/cli/state.go
@@ -32,6 +32,8 @@ type cState struct {
 	Status string `json:"status"`
 	// Created is the unix timestamp for the creation time of the container in UTC
 	Created time.Time `json:"created"`
+	// Owner is the user who creates the container, currently must be root
+	Owner string `json:"owner"`
 }
 
 var stateCommand = cli.Command{
@@ -102,6 +104,7 @@ func getContainer(context *cli.Context, name string) (*cState, error) {
 		Bundle:         state.Bundle,
 		Rootfs:         filepath.Join(state.Bundle, "rootfs"),
 		Created:        time.Unix(state.ContainerCreateTime, 0),
+		Owner:          defaultOwner,
 	}
 	return s, nil
 }

--- a/tests/bats-integration/ps.bats
+++ b/tests/bats-integration/ps.bats
@@ -46,6 +46,7 @@ function teardown() {
 
 @test "ps -e -x" {
   # ps is not supported, it requires cgroups
+  skip "runv ps does not support ps options"
   requires root
 
   # start busybox detached


### PR DESCRIPTION
To match runc outputs.

Also remove ps options and runv does not support it.

And add a default error code in case runv cli fails but no error is set.