### PR TITLE
respect cpu and memory settings in spec

### DIFF
--- a/cli/sandbox.go
+++ b/cli/sandbox.go
@@ -79,10 +79,6 @@ func setupFactory(context *cli.Context, spec *specs.Spec) (factory.Factory, erro
 }
 
 func createAndLockSandBox(f factory.Factory, spec *specs.Spec, cpu int, mem int) (*hypervisor.Vm, *os.File, error) {
-	if spec.Linux != nil && spec.Linux.Resources != nil && spec.Linux.Resources.Memory != nil && spec.Linux.Resources.Memory.Limit != nil {
-		mem = int(*spec.Linux.Resources.Memory.Limit >> 20)
-	}
-
 	vm, err := f.GetVm(cpu, mem)
 	if err != nil {
 		glog.Errorf("Create VM failed with err: %v", err)


### PR DESCRIPTION
For CPU, use Spec.Linux.Resources.CPU.Quota/Spec.Linux.Resources.CPU.Period.

For Memory, use Spec.Linux.Resources.Memory.Limit.
```
$docker run --rm -it --cpus 1.5 --memory 671088640 busybox sh
/ # cat /proc/cpuinfo |grep processor
processor       : 0
processor       : 1
/ # cat /proc/meminfo |grep MemTotal
MemTotal:         569512 kB
```

fixes https://github.com/hyperhq/runv/issues/586