### PR TITLE
return cleanly when return non-zero

### DIFF
--- a/cli/exec.go
+++ b/cli/exec.go
@@ -112,8 +112,6 @@ following will output a list of processes running in the container:
 		code, err := runProcess(context, container, cState, config)
 		if code != 0 {
 			return cli.NewExitError(err, code)
-		} else if err != nil {
-			return cli.NewExitError(err, -1)
 		}
 		return nil
 	},

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -144,9 +145,12 @@ func osProcessWait(process *os.Process) (int, error) {
 		return 0, nil
 	}
 
+	ret := -1
 	if status, ok := state.Sys().(syscall.WaitStatus); ok {
-		return status.ExitStatus(), err
+		ret = status.ExitStatus()
+		if ret != 0 {
+			err = errors.New("")
+		}
 	}
-
-	return -1, err
+	return ret, err
 }


### PR DESCRIPTION
remove the incorrectly appended "<nil>":

runv exec test_busybox command-does-not-exist
exec failed: No such file or directory
<nil>

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>