### PR TITLE
nslistener: save iptable rules of container into sharedir of vm

### DIFF
--- a/cli/sandbox.go
+++ b/cli/sandbox.go
@@ -202,6 +202,10 @@ func sandboxPath(vm *hypervisor.Vm) string {
 	return filepath.Join(hypervisor.BaseDir, vm.Id)
 }
 
+func shareDirPath(vm *hypervisor.Vm) string {
+	return filepath.Join(hypervisor.BaseDir, vm.Id, hypervisor.ShareDirTag)
+}
+
 func setupHyperstartFunc(context *cli.Context) {
 	libhyperstart.NewHyperstart = func(vmid, ctlSock, streamSock string, lastStreamSeq uint64, waitReady, paused bool) (libhyperstart.Hyperstart, error) {
 		return newHyperstart(context, vmid, ctlSock, streamSock)


### PR DESCRIPTION
docker use these iptable rules to implement port mapping, store
these rules and hyperstart will restore them.

hyperstart part pr https://github.com/hyperhq/hyperstart/pull/337
fix https://github.com/hyperhq/runv/issues/582

Signed-off-by: Gao feng <omarapazanadi@gmail.com>