### PR TITLE
disable iommu for hyper kernel

### DIFF
--- a/hypervisor/kvmtool/lkvm.go
+++ b/hypervisor/kvmtool/lkvm.go
@@ -85,7 +85,7 @@ func arguments(ctx *hypervisor.VmContext) []string {
 		"run", "-k", boot.Kernel, "-i", boot.Initrd, "-m", memParams,
 		"-c", cpuParams, "--name", ctx.Id}
 	//use ttyS0 as kernel console
-	args = append(args, "-p", "console=ttyS0 "+json.HYPER_USE_SERIAL)
+	args = append(args, "-p", "iommu=off console=ttyS0 "+json.HYPER_USE_SERIAL)
 
 	// kvmtool enforce uses ttyS0 as console,
 	// hyperstart can only use ttyS1 and ttyS2 as ctl and tty channel.

--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -448,7 +448,7 @@ func (lc *LibvirtContext) domainXml(ctx *hypervisor.VmContext) (string, error) {
 	dom.SecLabel.Type = "none"
 
 	dom.CPU.Mode = "host-passthrough"
-	cmdline := "console=ttyS0 panic=1 no_timer_check"
+	cmdline := "console=ttyS0 panic=1 no_timer_check iommu=off"
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
 		dom.Type = "qemu"
 		dom.CPU.Mode = "host-model"

--- a/hypervisor/qemu/qemu_amd64.go
+++ b/hypervisor/qemu/qemu_amd64.go
@@ -31,7 +31,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 	memParams = fmt.Sprintf("size=%d,slots=1,maxmem=%dM", boot.Memory, hypervisor.DefaultMaxMem) // TODO set maxmem to the total memory of the system
 	cpuParams = fmt.Sprintf("cpus=%d,maxcpus=%d", boot.CPU, hypervisor.DefaultMaxCpus)           // TODO set it to the cpus of the system
 
-	cmdline := "console=ttyS0 panic=1 no_timer_check"
+	cmdline := "console=ttyS0 panic=1 no_timer_check iommu=off"
 	params := []string{
 		"-machine", machineClass + ",accel=kvm,usb=off", "-global", "kvm-pit.lost_tick_policy=discard", "-cpu", "host"}
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {

--- a/hypervisor/qemu/qemu_arm64.go
+++ b/hypervisor/qemu/qemu_arm64.go
@@ -77,7 +77,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 	}
 
 	return append(params,
-		"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyAMA0 panic=1",
+		"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyAMA0 panic=1 iommu=no",
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults",
 		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams,


### PR DESCRIPTION
After kernel commit ec941c5ffede4d788b9fc008f9eeca75b9e964f5,
the kernel will reserve 64M memory for swiotlb, this reduce
the available memory for container.

runv doesn't need iommu now, enable it when necessary.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>