### PR TITLE
change func name StartServer into NewServer

### DIFF
--- a/cli/proxy.go
+++ b/cli/proxy.go
@@ -85,10 +85,10 @@ var proxyCommand = cli.Command{
 		}
 
 		grpcSock := context.String("proxy-hyperstart")
-		glog.Infof("proxy.StartServer")
-		s, err = proxy.StartServer(grpcSock, h)
+		glog.Infof("proxy.NewServer")
+		s, err = proxy.NewServer(grpcSock, h)
 		if err != nil {
-			glog.Errorf("proxy.StartServer() failed with err: %#v", err)
+			glog.Errorf("proxy.NewServer() failed with err: %#v", err)
 			return err
 		}
 		if _, err := os.Stat(grpcSock); !os.IsNotExist(err) {

--- a/hyperstart/proxy/proxy.go
+++ b/hyperstart/proxy/proxy.go
@@ -148,8 +148,8 @@ func (proxy *jsonProxy) OnlineCPUMem(ctx context.Context, req *hyperstartgrpc.On
 	return pbEmpty(err), err
 }
 
-func StartServer(address string, json libhyperstart.Hyperstart) (*grpc.Server, error) {
-
+// NewServer initializes a brand new grpc server with registered grpc services
+func NewServer(address string, json libhyperstart.Hyperstart) (*grpc.Server, error) {
 	s := grpc.NewServer()
 	jp := &jsonProxy{
 		json: json,


### PR DESCRIPTION
When I was learning runV, I found that in a place maybe func name `NewServer` is a little bit more proper than `StartServer`.

Since the function only initialize a grpc server with registered grpc service, util `s.Serve(l)` the grpc server starts to work.

Just with very junior background with runV, if I missed something here, please feel free to correct me. Thanks a lot.

Signed-off-by: Allen Sun <shlallen1990@gmail.com>