### PR TITLE
remove unused package os

### DIFF
--- a/hypervisor/network/network_darwin.go
+++ b/hypervisor/network/network_darwin.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/hyperhq/runv/api"
 )


### PR DESCRIPTION
My IDE reports an error for me that "os" package is imported and unused.
I checked that and found it is true.

So I try to remove unused package os in this PR.

Signed-off-by: Allen Sun <shlallen1990@gmail.com>