### PR TITLE
make network test compile error free

### DIFF
--- a/hypervisor/network/network_linux.go
+++ b/hypervisor/network/network_linux.go
@@ -137,11 +137,13 @@ func createBridgeIface(name string, addr *net.IPNet) error {
 }
 
 func DeleteBridge(name string) error {
-	if bridge, err := netlink.LinkByName(BridgeIface); err != nil {
-		glog.Errorf("cannot find bridge %v", name)
-	} else {
-		netlink.LinkDel(bridge)
+	bridge, err := netlink.LinkByName(BridgeIface)
+	if err != nil {
+		glog.Errorf("cannot find bridge %v: %v", name, err)
+		return err
 	}
+
+	netlink.LinkDel(bridge)
 	return nil
 }
 

--- a/hypervisor/network/network_test.go
+++ b/hypervisor/network/network_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package network
 
 import (
@@ -5,7 +7,7 @@ import (
 )
 
 func TestInitNetwork(t *testing.T) {
-	if err := InitNetwork("hyper-test", "192.168.138.1/24"); err != nil {
+	if err := InitNetwork("hyper-test", "192.168.138.1/24", false); err != nil {
 		t.Error("create hyper-test bridge failed")
 	}
 
@@ -17,17 +19,16 @@ func TestInitNetwork(t *testing.T) {
 }
 
 func TestAllocate(t *testing.T) {
-	if err := InitNetwork("hyper-test", "192.168.138.1/24"); err != nil {
+	if err := InitNetwork("hyper-test", "192.168.138.1/24", false); err != nil {
 		t.Error("create hyper-test bridge failed")
 	}
 
-	if setting, err := Allocate("192.168.138.2"); err != nil {
+	if setting, err := AllocateAddr("192.168.138.2"); err != nil {
 		t.Error("allocate tap device and ip failed")
 	} else {
 		t.Logf("alocate tap device finished. bridge %s, device %s, ip %s, gateway %s",
 			setting.Bridge, setting.Device, setting.IPAddress, setting.Gateway)
-
-		if err := Release("192.168.138.2", setting.File); err != nil {
+		if err := ReleaseAddr("192.168.138.2"); err != nil {
 			t.Error("release ip failed")
 		}
 	}


### PR DESCRIPTION
I found that network_test.go are unable to be compiled.
This PR tries to update network_test.go to make it compile error free.

Signed-off-by: Allen Sun <shlallen1990@gmail.com>