### PR TITLE
docs: add more containerd info

### DIFF
--- a/docs/configure-runv-with-containerd-docker.md
+++ b/docs/configure-runv-with-containerd-docker.md
@@ -30,7 +30,7 @@ $ sudo make install
 ```
 
 ## Work with containerd
-First, install containerd and save its default configuration to `/etc/containerd/config.toml`, which is the default configuration file containerd looks for.
+First, install [containerd](https://github.com/containerd/containerd) in the [containerd release page](https://github.com/containerd/containerd/releases), then save its default configuration to `/etc/containerd/config.toml`, which is the default configuration file containerd looks for.
 
 ```
 $containerd config default > /etc/containerd/config.toml


### PR DESCRIPTION
add more containerd infomations in docs, make
users more easily to get runv worked with containerd

Signed-off-by: Ace-Tang <aceapril@126.com>

I think this may get more clearly about get runv work with containerd, thanks