### PR TITLE
let runv create bridge

### DIFF
--- a/hypervisor/events.go
+++ b/hypervisor/events.go
@@ -52,6 +52,7 @@ type InterfaceCreated struct {
 	Id         string //user specified in (ref api.InterfaceDescription: a user identifier of interface, user may use this to specify a nic, normally you can use IPAddr as an Id.)
 	Index      int
 	PCIAddr    int
+	TapFd      int
 	Bridge     string
 	HostDevice string
 	DeviceName string
@@ -73,6 +74,7 @@ type NetDevInsertedEvent struct {
 	Index      int
 	DeviceName string
 	Address    int
+	TapFd      int
 }
 
 func (ne *NetDevInsertedEvent) ResultId() string {

--- a/hypervisor/network.go
+++ b/hypervisor/network.go
@@ -173,6 +173,8 @@ func (nc *NetworkContext) addInterface(inf *api.InterfaceDescription, result cha
 			result <- fe
 			return
 		} else if ni, ok := ev.(*NetDevInsertedEvent); ok {
+			created := nc.idMap[inf.Id]
+			created.TapFd = ni.TapFd
 			nc.sandbox.Log(DEBUG, "nic insert success: %s", ni.Id)
 			result <- ni
 			return

--- a/hypervisor/qemu/network.go
+++ b/hypervisor/qemu/network.go
@@ -4,31 +4,58 @@ package qemu
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+	"unsafe"
 
 	"github.com/golang/glog"
 	"github.com/hyperhq/runv/hypervisor/network"
-	"github.com/vishvananda/netlink"
 )
 
-func GetTapDevice(device, bridge, options string) error {
-	la := netlink.NewLinkAttrs()
-	la.Name = device
-	tapdev := &netlink.Tuntap{LinkAttrs: la, Mode: syscall.IFF_TAP}
+const (
+	IFNAMSIZ       = 16
+	CIFF_TAP       = 0x0002
+	CIFF_NO_PI     = 0x1000
+	CIFF_ONE_QUEUE = 0x2000
+)
 
-	if err := netlink.LinkAdd(tapdev); err != nil {
-		glog.Errorf("fail to create tap device: %v, %v", device, err)
-		return err
+type ifReq struct {
+	Name  [IFNAMSIZ]byte
+	Flags uint16
+	pad   [0x28 - 0x10 - 2]byte
+}
+
+func GetTapFd(device, bridge, options string) (int, error) {
+	var (
+		req   ifReq
+		errno syscall.Errno
+	)
+
+	tapFile, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
+	if err != nil {
+		return -1, err
 	}
 
-	if err := network.UpAndAddToBridge(device, bridge, options); err != nil {
+	req.Flags = CIFF_TAP | CIFF_NO_PI | CIFF_ONE_QUEUE
+	copy(req.Name[:len(req.Name)-1], []byte(device))
+	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, tapFile.Fd(),
+		uintptr(syscall.TUNSETIFF),
+		uintptr(unsafe.Pointer(&req)))
+	if errno != 0 {
+		tapFile.Close()
+		return -1, fmt.Errorf("create tap device failed\n")
+	}
+
+	err = network.UpAndAddToBridge(device, bridge, options)
+	if err != nil {
 		glog.Errorf("Add to bridge failed %s %s", bridge, device)
-		return err
+		tapFile.Close()
+		return -1, err
 	}
 
-	return nil
+	return int(tapFile.Fd()), nil
 }
 
 func GetVhostUserPort(device, bridge, sockPath, option string) error {

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -283,10 +283,13 @@ func (qc *QemuContext) AddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNi
 	go func() {
 		// close tap file if necessary
 		ev, ok := <-waitChan
-		syscall.Close(fd)
 		if !ok {
+			syscall.Close(fd)
 			close(result)
 		} else {
+			if _, ok := ev.(*hypervisor.DeviceFailed); ok {
+				syscall.Close(fd)
+			}
 			result <- ev
 		}
 	}()

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -290,7 +290,7 @@ func (qc *QemuContext) AddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNi
 			result <- ev
 		}
 	}()
-	newNetworkAddSession(ctx, qc, host.Id, host.Device, fd, guest.Device, host.Mac, guest.Index, guest.Busaddr, waitChan)
+	newNetworkAddSession(ctx, qc, fd, host, guest, waitChan)
 }
 
 func (qc *QemuContext) RemoveNic(ctx *hypervisor.VmContext, n *hypervisor.InterfaceCreated, callback hypervisor.VmEvent, result chan<- hypervisor.VmEvent) {

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -260,13 +260,16 @@ func (qc *QemuContext) RemoveDisk(ctx *hypervisor.VmContext, blockInfo *hypervis
 }
 
 func (qc *QemuContext) AddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo, result chan<- hypervisor.VmEvent) {
-	waitChan := make(chan hypervisor.VmEvent, 1)
-	var err error = nil
+	var (
+		fd       int = -1
+		err      error
+		waitChan chan hypervisor.VmEvent = make(chan hypervisor.VmEvent, 1)
+	)
 
 	if ctx.Boot.EnableVhostUser {
 		err = GetVhostUserPort(host.Device, host.Bridge, ctx.HomeDir, host.Options)
 	} else {
-		err = GetTapDevice(host.Device, host.Bridge, host.Options)
+		fd, err = GetTapFd(host.Device, host.Bridge, host.Options)
 	}
 
 	if err != nil {
@@ -280,13 +283,14 @@ func (qc *QemuContext) AddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNi
 	go func() {
 		// close tap file if necessary
 		ev, ok := <-waitChan
+		syscall.Close(fd)
 		if !ok {
 			close(result)
 		} else {
 			result <- ev
 		}
 	}()
-	newNetworkAddSession(ctx, qc, host, guest, waitChan)
+	newNetworkAddSession(ctx, qc, host.Id, host.Device, fd, guest.Device, host.Mac, guest.Index, guest.Busaddr, waitChan)
 }
 
 func (qc *QemuContext) RemoveNic(ctx *hypervisor.VmContext, n *hypervisor.InterfaceCreated, callback hypervisor.VmEvent, result chan<- hypervisor.VmEvent) {

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -297,6 +297,7 @@ func (qc *QemuContext) AddNic(ctx *hypervisor.VmContext, host *hypervisor.HostNi
 }
 
 func (qc *QemuContext) RemoveNic(ctx *hypervisor.VmContext, n *hypervisor.InterfaceCreated, callback hypervisor.VmEvent, result chan<- hypervisor.VmEvent) {
+	syscall.Close(n.TapFd)
 	newNetworkDelSession(ctx, qc, n.NewName, callback, result)
 }
 

--- a/hypervisor/qemu/qmp_wrapper_amd64.go
+++ b/hypervisor/qemu/qmp_wrapper_amd64.go
@@ -4,15 +4,17 @@ package qemu
 
 import (
 	"fmt"
+	"syscall"
 
+	"github.com/golang/glog"
 	"github.com/hyperhq/runv/hypervisor"
 )
 
-func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo, result chan<- hypervisor.VmEvent) {
-	busAddr := fmt.Sprintf("0x%x", guest.Busaddr)
+func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, id, tapname string, fd int, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
+	busAddr := fmt.Sprintf("0x%x", addr)
 	commands := []*QmpCommand{}
 	if ctx.Boot.EnableVhostUser {
-		chardevId := guest.Device + "-chardev"
+		chardevId := device + "-chardev"
 		commands = append(commands, &QmpCommand{
 			Execute: "chardev-add",
 			Arguments: map[string]interface{}{
@@ -23,7 +25,7 @@ func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, host *hype
 						"addr": map[string]interface{}{
 							"type": "unix",
 							"data": map[string]interface{}{
-								"path": ctx.HomeDir + "/" + host.Id,
+								"path": ctx.HomeDir + "/" + id,
 							},
 						},
 						"wait":   false,
@@ -35,20 +37,31 @@ func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, host *hype
 			Execute: "netdev_add",
 			Arguments: map[string]interface{}{
 				"type":       "vhost-user",
-				"id":         guest.Device,
+				"id":         device,
 				"chardev":    chardevId,
 				"vhostforce": true,
 			},
 		})
-	} else {
+	} else if fd > 0 {
+		scm := syscall.UnixRights(fd)
+		glog.V(1).Infof("send net to qemu at %d", fd)
+		commands = append(commands, &QmpCommand{
+			Execute: "getfd",
+			Arguments: map[string]interface{}{
+				"fdname": "fd" + device,
+			},
+			Scm: scm,
+		}, &QmpCommand{
+			Execute: "netdev_add",
+			Arguments: map[string]interface{}{
+				"type": "tap", "id": device, "fd": "fd" + device,
+			},
+		})
+	} else if tapname != "" {
 		commands = append(commands, &QmpCommand{
 			Execute: "netdev_add",
 			Arguments: map[string]interface{}{
-				"type":   "tap",
-				"script": "no",
-				"id":     guest.Device,
-				"ifname": host.Device,
-				"br":     host.Bridge,
+				"type": "tap", "id": device, "ifname": tapname, "script": "no",
 			},
 		})
 	}
@@ -56,21 +69,21 @@ func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, host *hype
 		Execute: "device_add",
 		Arguments: map[string]interface{}{
 			"driver": "virtio-net-pci",
-			"netdev": guest.Device,
-			"mac":    host.Mac,
+			"netdev": device,
+			"mac":    mac,
 			"bus":    "pci.0",
 			"addr":   busAddr,
-			"id":     guest.Device,
+			"id":     device,
 		},
 	})
 
 	qc.qmp <- &QmpSession{
 		commands: commands,
 		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
-			Id:         host.Id,
-			Index:      guest.Index,
-			DeviceName: guest.Device,
-			Address:    guest.Busaddr,
+			Id:         id,
+			Index:      index,
+			DeviceName: device,
+			Address:    addr,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_amd64.go
+++ b/hypervisor/qemu/qmp_wrapper_amd64.go
@@ -84,6 +84,7 @@ func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd int, ho
 			Index:      guest.Index,
 			DeviceName: guest.Device,
 			Address:    guest.Busaddr,
+			TapFd:      fd,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_arm64.go
+++ b/hypervisor/qemu/qmp_wrapper_arm64.go
@@ -4,44 +4,51 @@ package qemu
 
 import (
 	"fmt"
+	"syscall"
 
+	"github.com/golang/glog"
 	"github.com/hyperhq/runv/hypervisor"
 )
 
-func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo, result chan<- hypervisor.VmEvent) {
-	busAddr := fmt.Sprintf("0x%x", guest.Busaddr)
-	commands := []*QmpCommand{}
-	commands = append(commands, &QmpCommand{
+func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, id string, fd int, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
+	busAddr := fmt.Sprintf("0x%x", addr)
+	commands := make([]*QmpCommand, 3)
+	scm := syscall.UnixRights(fd)
+	glog.V(1).Infof("send net to qemu at %d", fd)
+	commands[0] = &QmpCommand{
+		Execute: "getfd",
+		Arguments: map[string]interface{}{
+			"fdname": "fd" + device,
+		},
+		Scm: scm,
+	}
+	commands[1] = &QmpCommand{
 		Execute: "netdev_add",
 		Arguments: map[string]interface{}{
-			"type":   "tap",
-			"script": "no",
-			"id":     guest.Device,
-			"ifname": host.Device,
-			"br":     host.Bridge,
+			"type": "tap", "id": device, "fd": "fd" + device,
 		},
-	})
-	commands = append(commands, &QmpCommand{
+	}
+	commands[2] = &QmpCommand{
 		Execute: "device_add",
 		Arguments: map[string]interface{}{
-			"netdev":         guest.Device,
+			"netdev":         device,
 			"driver":         "virtio-net-pci",
 			"disable-modern": "off",
 			"disable-legacy": "on",
 			"bus":            "pci.0",
 			"addr":           busAddr,
-			"mac":            host.Mac,
-			"id":             guest.Device,
+			"mac":            mac,
+			"id":             device,
 		},
-	})
+	}
 
 	qc.qmp <- &QmpSession{
 		commands: commands,
 		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
-			Id:         host.Id,
-			Index:      guest.Index,
-			DeviceName: guest.Device,
-			Address:    guest.Busaddr,
+			Id:         id,
+			Index:      index,
+			DeviceName: device,
+			Address:    addr,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_arm64.go
+++ b/hypervisor/qemu/qmp_wrapper_arm64.go
@@ -10,45 +10,45 @@ import (
 	"github.com/hyperhq/runv/hypervisor"
 )
 
-func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, id string, fd int, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
-	busAddr := fmt.Sprintf("0x%x", addr)
+func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd int, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo, result chan<- hypervisor.VmEvent) {
+	busAddr := fmt.Sprintf("0x%x", guest.Busaddr)
 	commands := make([]*QmpCommand, 3)
 	scm := syscall.UnixRights(fd)
 	glog.V(1).Infof("send net to qemu at %d", fd)
 	commands[0] = &QmpCommand{
 		Execute: "getfd",
 		Arguments: map[string]interface{}{
-			"fdname": "fd" + device,
+			"fdname": "fd" + guest.Device,
 		},
 		Scm: scm,
 	}
 	commands[1] = &QmpCommand{
 		Execute: "netdev_add",
 		Arguments: map[string]interface{}{
-			"type": "tap", "id": device, "fd": "fd" + device,
+			"type": "tap", "id": guest.Device, "fd": "fd" + guest.Device,
 		},
 	}
 	commands[2] = &QmpCommand{
 		Execute: "device_add",
 		Arguments: map[string]interface{}{
-			"netdev":         device,
+			"netdev":         guest.Device,
 			"driver":         "virtio-net-pci",
 			"disable-modern": "off",
 			"disable-legacy": "on",
 			"bus":            "pci.0",
 			"addr":           busAddr,
-			"mac":            mac,
-			"id":             device,
+			"mac":            host.Mac,
+			"id":             guest.Device,
 		},
 	}
 
 	qc.qmp <- &QmpSession{
 		commands: commands,
 		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
-			Id:         id,
-			Index:      index,
-			DeviceName: device,
-			Address:    addr,
+			Id:         host.Id,
+			Index:      guest.Index,
+			DeviceName: guest.Device,
+			Address:    guest.Busaddr,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_arm64.go
+++ b/hypervisor/qemu/qmp_wrapper_arm64.go
@@ -49,6 +49,7 @@ func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd int, ho
 			Index:      guest.Index,
 			DeviceName: guest.Device,
 			Address:    guest.Busaddr,
+			TapFd:      fd,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_ppc64le.go
+++ b/hypervisor/qemu/qmp_wrapper_ppc64le.go
@@ -10,43 +10,43 @@ import (
 	"github.com/hyperhq/runv/hypervisor"
 )
 
-func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, id string, fd int, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
-	busAddr := fmt.Sprintf("0x%x", addr)
+func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd int, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo, result chan<- hypervisor.VmEvent) {
+	busAddr := fmt.Sprintf("0x%x", guest.Busaddr)
 	commands := make([]*QmpCommand, 3)
 	scm := syscall.UnixRights(fd)
 	glog.V(1).Infof("send net to qemu at %d", fd)
 	commands[0] = &QmpCommand{
 		Execute: "getfd",
 		Arguments: map[string]interface{}{
-			"fdname": "fd" + device,
+			"fdname": "fd" + guest.Device,
 		},
 		Scm: scm,
 	}
 	commands[1] = &QmpCommand{
 		Execute: "netdev_add",
 		Arguments: map[string]interface{}{
-			"type": "tap", "id": device, "fd": "fd" + device,
+			"type": "tap", "id": guest.Device, "fd": "fd" + guest.Device,
 		},
 	}
 	commands[2] = &QmpCommand{
 		Execute: "device_add",
 		Arguments: map[string]interface{}{
 			"driver": "virtio-net-pci",
-			"netdev": device,
-			"mac":    mac,
+			"netdev": guest.Device,
+			"mac":    host.Mac,
 			"bus":    "pci.0",
 			"addr":   busAddr,
-			"id":     device,
+			"id":     guest.Device,
 		},
 	}
 
 	qc.qmp <- &QmpSession{
 		commands: commands,
 		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
-			Id:         id,
-			Index:      index,
-			DeviceName: device,
-			Address:    addr,
+			Id:         host.Id,
+			Index:      guest.Index,
+			DeviceName: guest.Device,
+			Address:    guest.Busaddr,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_ppc64le.go
+++ b/hypervisor/qemu/qmp_wrapper_ppc64le.go
@@ -47,6 +47,7 @@ func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd int, ho
 			Index:      guest.Index,
 			DeviceName: guest.Device,
 			Address:    guest.Busaddr,
+			TapFd:      fd,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_s390x.go
+++ b/hypervisor/qemu/qmp_wrapper_s390x.go
@@ -9,40 +9,40 @@ import (
 	"github.com/hyperhq/runv/hypervisor"
 )
 
-func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, id string, fd int, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
+func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd int, host *hypervisor.HostNicInfo, guest *hypervisor.GuestNicInfo, result chan<- hypervisor.VmEvent) {
 	commands := make([]*QmpCommand, 3)
 	scm := syscall.UnixRights(fd)
 	glog.V(1).Infof("send net to qemu at %d", fd)
 	commands[0] = &QmpCommand{
 		Execute: "getfd",
 		Arguments: map[string]interface{}{
-			"fdname": "fd" + device,
+			"fdname": "fd" + guest.Device,
 		},
 		Scm: scm,
 	}
 	commands[1] = &QmpCommand{
 		Execute: "netdev_add",
 		Arguments: map[string]interface{}{
-			"type": "tap", "id": device, "fd": "fd" + device,
+			"type": "tap", "id": guest.Device, "fd": "fd" + guest.Device,
 		},
 	}
 	commands[2] = &QmpCommand{
 		Execute: "device_add",
 		Arguments: map[string]interface{}{
 			"driver": "virtio-net-ccw",
-			"netdev": device,
-			"mac":    mac,
-			"id":     device,
+			"netdev": guest.Device,
+			"mac":    host.Mac,
+			"id":     guest.Device,
 		},
 	}
 
 	qc.qmp <- &QmpSession{
 		commands: commands,
 		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
-			Id:         id,
-			Index:      index,
-			DeviceName: device,
-			Address:    addr,
+			Id:         host.Id,
+			Index:      guest.Index,
+			DeviceName: guest.Device,
+			Address:    guest.Busaddr,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_s390x.go
+++ b/hypervisor/qemu/qmp_wrapper_s390x.go
@@ -10,35 +10,39 @@ import (
 )
 
 func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, id string, fd int, device, mac string, index, addr int, result chan<- hypervisor.VmEvent) {
-	commands := []*QmpCommand{}
+	commands := make([]*QmpCommand, 3)
 	scm := syscall.UnixRights(fd)
-	commands = appends(commands, &QmpCommand{
+	glog.V(1).Infof("send net to qemu at %d", fd)
+	commands[0] = &QmpCommand{
+		Execute: "getfd",
+		Arguments: map[string]interface{}{
+			"fdname": "fd" + device,
+		},
+		Scm: scm,
+	}
+	commands[1] = &QmpCommand{
 		Execute: "netdev_add",
 		Arguments: map[string]interface{}{
-			"type":   "tap",
-			"script": "no",
-			"id":     guest.Device,
-			"ifname": host.Device,
-			"br":     host.Bridge,
+			"type": "tap", "id": device, "fd": "fd" + device,
 		},
-	})
-	commands = append(commands, &QmpCommand{
+	}
+	commands[2] = &QmpCommand{
 		Execute: "device_add",
 		Arguments: map[string]interface{}{
 			"driver": "virtio-net-ccw",
-			"netdev": guest.Device,
-			"mac":    host.Mac,
-			"id":     guest.Device,
+			"netdev": device,
+			"mac":    mac,
+			"id":     device,
 		},
-	})
+	}
 
 	qc.qmp <- &QmpSession{
 		commands: commands,
 		respond: defaultRespond(result, &hypervisor.NetDevInsertedEvent{
-			Id:         host.Id,
-			Index:      guest.Index,
-			DeviceName: guest.Device,
-			Address:    guest.Busaddr,
+			Id:         id,
+			Index:      index,
+			DeviceName: device,
+			Address:    addr,
 		}),
 	}
 }

--- a/hypervisor/qemu/qmp_wrapper_s390x.go
+++ b/hypervisor/qemu/qmp_wrapper_s390x.go
@@ -43,6 +43,7 @@ func newNetworkAddSession(ctx *hypervisor.VmContext, qc *QemuContext, fd int, ho
 			Index:      guest.Index,
 			DeviceName: guest.Device,
 			Address:    guest.Busaddr,
+			TapFd:      fd,
 		}),
 	}
 }


### PR DESCRIPTION
The PR partly reverts 7b44d4dbf2db1460f1f5424fb000c0b40f232d99 ("qemu: cleanup: simplify qmp code") because it would require qemu version (>2.7).

Also fix a tap fd handling bug that constantly causes hyperd CI failures.