### PR TITLE
fix TestListSleepJson test

### DIFF
--- a/tests/go-integration/list_test.go
+++ b/tests/go-integration/list_test.go
@@ -86,7 +86,6 @@ func (s *RunVSuite) TestListSleepJson(c *check.C) {
 			c.Assert(cs.ID, check.Equals, ctrName)
 			c.Assert(cs.Pid, checker.Not(checker.Equals), 0)
 			c.Assert(cs.Bundle, checker.Equals, s.bundlePath)
-			c.Assert(cs.Status, checker.Equals, "running")
 			flag = 0
 			break
 		}


### PR DESCRIPTION
When we state the container, there is not guarantee that the container
is started. Therefore we see random failures in TestListSleepJson test such as https://travis-ci.org/hyperhq/runv/builds/291474867?utm_source=github_status&utm_medium=notification