### PR TITLE
Detect the correct irpchip for arm platforms while using kvmtool

### DIFF
--- a/hypervisor/kvmtool/lkvm_arm64.go
+++ b/hypervisor/kvmtool/lkvm_arm64.go
@@ -2,6 +2,40 @@
 
 package kvmtool
 
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// On ARM platform, we have different gic interrupt controllers.
+// We have to detect the correct gic chip to set parameter for lkvm.
+func getGicInfo() (info string) {
+	gicinfo, err := os.Open("/proc/interrupts")
+	if err != nil {
+		return "unknown"
+	}
+
+	defer gicinfo.Close()
+
+	scanner := bufio.NewScanner(gicinfo)
+	for scanner.Scan() {
+		newline := scanner.Text()
+		list := strings.Fields(newline)
+
+		for _, item := range list {
+			if strings.EqualFold(item, "GICv2") {
+				return "gicv2"
+			} else if strings.EqualFold(item, "GICv3") ||
+				strings.EqualFold(item, "GICv4") {
+				return "gicv3"
+			}
+		}
+	}
+
+	return "unknown"
+}
+
 func arch_arguments() []string {
-	return []string{"--irqchip", "gicv3"}
+	return []string{"--irqchip", getGicInfo()}
 }


### PR DESCRIPTION
kvmtool supports 3 kinds of virtual irqchip for arm platforms: gicv2, gicv3 and
gicv3-its. But these 3 kinds of virtual irqchip must have correct real irqchip
to support them.  In current code, we fix the irqchip to gicv3. This may work fine
for those systems that are using gicv3 or gicv4. But on a system with gicv2 or gicv2m,
the kvmtool could not start properly.

In this PR, we detect the irqchip type from /proc/interrupt to solve this issue.