### PR TITLE
proxy: Wait READY message for before send messages to hyperstart

### DIFF
--- a/cli/proxy.go
+++ b/cli/proxy.go
@@ -45,8 +45,9 @@ var proxyCommand = cli.Command{
 			context.String("hyperstart-stream-sock") == "" || context.String("proxy-hyperstart") == "" {
 			return err
 		}
+
 		glog.Infof("agent.NewJsonBasedHyperstart")
-		h, _ := agent.NewJsonBasedHyperstart(context.String("vmid"), context.String("hyperstart-ctl-sock"), context.String("hyperstart-stream-sock"), 1, false, false)
+		h, _ := agent.NewJsonBasedHyperstart(context.String("vmid"), context.String("hyperstart-ctl-sock"), context.String("hyperstart-stream-sock"), 1, true, false)
 
 		var s *grpc.Server
 		grpcSock := context.String("proxy-hyperstart")


### PR DESCRIPTION
Hi,

After the runv update to the latest upstream. I found the runv could not work properly with the lkvm.
There are two reasons cause such result.
1. We have moved the VM console connect code to a standalone function. But we call the function
    before grpcSock created. But this function could not return before proxy.NewServer completed.
2. We have ignore the READY message. This will cause the communication between runv and hyperstart
    could not work properly, especially on some old server, the VM could not boot very quickly.

Regards,
Wei Chen