### PR TITLE
qemu: clear persist flag on tap device

### DIFF
--- a/hypervisor/qemu/network.go
+++ b/hypervisor/qemu/network.go
@@ -47,6 +47,11 @@ func GetTapFd(device, bridge, options string) (int, error) {
 		tapFile.Close()
 		return -1, fmt.Errorf("create tap device failed\n")
 	}
+	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, tapFile.Fd(), uintptr(syscall.TUNSETPERSIST), 0)
+	if errno != 0 {
+		tapFile.Close()
+		return -1, fmt.Errorf("clear tap device persist flag failed\n")
+	}
 
 	err = network.UpAndAddToBridge(device, bridge, options)
 	if err != nil {


### PR DESCRIPTION
In the scenario which tap device was not created by qemu but passed
in(e.g, with some cni plugin), there was IFF_PERSIST flag set on it,
the flag need to be cleared to make sure tap device removed cleanly
on qemu exit.

(cherry picked from commit c3fbef2bb406e589c11286807ff6243687c8377a)