### PR TITLE
cli: add namespace requirements to default spec

### DIFF
--- a/cli/spec.go
+++ b/cli/spec.go
@@ -46,6 +46,12 @@ var specCommand = cli.Command{
 			Hostname: "shell",
 			Linux: &specs.Linux{
 				Resources: &specs.LinuxResources{},
+				Namespaces: []specs.LinuxNamespace{
+					{Type: "pid"},
+					{Type: "network"},
+					{Type: "ipc"},
+					{Type: "uts"},
+				},
 			},
 		}
 

--- a/tests/go-integration/init_test.go
+++ b/tests/go-integration/init_test.go
@@ -49,6 +49,12 @@ var (
 		Hostname: "shell",
 		Linux: &specs.Linux{
 			Resources: &specs.LinuxResources{},
+			Namespaces: []specs.LinuxNamespace{
+				{Type: "pid"},
+				{Type: "network"},
+				{Type: "ipc"},
+				{Type: "uts"},
+			},
 		},
 	}
 )


### PR DESCRIPTION
So that the Kata agent can run a bundle with the default spec.