### PR TITLE
Dummy.GetVm: set config.BootFromTemplate to false to fix vm start fai…

### DIFF
--- a/factory/single/single.go
+++ b/factory/single/single.go
@@ -59,6 +59,7 @@ func (f Dummy) GetVm(cpu, mem int) (*hypervisor.Vm, error) {
 	config := hypervisor.BootConfig(f)
 	config.CPU = cpu
 	config.Memory = mem
+	config.BootFromTemplate = false
 	return hypervisor.GetVm("", &config, false)
 }
 func (f Dummy) CloseFactory() {}


### PR DESCRIPTION
…l issue

config.BootFromTemplate will be set to true without this patch.
Then QemuContext.arguments will return wrong params for qemu.