### PR TITLE
QemuContext.arguments: change rtc clock option from vm to host

### DIFF
--- a/hypervisor/libvirt/libvirt.go
+++ b/hypervisor/libvirt/libvirt.go
@@ -502,7 +502,7 @@ func (lc *LibvirtContext) domainXml(ctx *hypervisor.VmContext) (string, error) {
 	dom.OnCrash = "destroy"
 
 	dom.Clock.Offset = "utc"
-	dom.Clock.Timer = append(dom.Clock.Timer, timer{Name: "rtc", Track: "guest", Tickpolicy: "catchup"})
+	dom.Clock.Timer = append(dom.Clock.Timer, timer{Name: "rtc", Track: "wall", Tickpolicy: "catchup"})
 
 	pcicontroller := controller{
 		Type:  "pci",

--- a/hypervisor/qemu/qemu_amd64.go
+++ b/hypervisor/qemu/qemu_amd64.go
@@ -58,7 +58,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 
 	params = append(params,
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults", "-no-hpet",
-		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-rtc", "base=utc,clock=host,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams)
 	if boot.EnableVhostUser {
 		//TODO: mount hugetlbfs on /dev/hugepages

--- a/hypervisor/qemu/qemu_arm64.go
+++ b/hypervisor/qemu/qemu_arm64.go
@@ -43,7 +43,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 	return append(params,
 		"-kernel", boot.Kernel, "-initrd", boot.Initrd, "-append", "console=ttyAMA0 panic=1 iommu=no",
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults",
-		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-rtc", "base=utc,clock=host,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams,
 		"-device", "pci-bridge,chassis_nr=1,id=pci.0",
 		"-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName), "-serial", fmt.Sprintf("unix:%s,server,nowait", ctx.ConsoleSockName),

--- a/hypervisor/qemu/qemu_ppc64le.go
+++ b/hypervisor/qemu/qemu_ppc64le.go
@@ -40,7 +40,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 		"-machine", "pseries,accel=kvm,usb=off", "-global", "kvm-pit.lost_tick_policy=discard", "-cpu", "host",
 		"-kernel", boot.Kernel, "-initrd", boot.Initrd,
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults",
-		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-rtc", "base=utc,clock=host,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams,
 		"-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName), "-serial", fmt.Sprintf("unix:%s,server,nowait", ctx.ConsoleSockName),
 		"-device", "virtio-serial-pci,id=virtio-serial0,bus=pci.0,addr=0x2", "-device", "virtio-scsi-pci,id=scsi0,bus=pci.0,addr=0x3",

--- a/hypervisor/qemu/qemu_s390x.go
+++ b/hypervisor/qemu/qemu_s390x.go
@@ -34,7 +34,7 @@ func (qc *QemuContext) arguments(ctx *hypervisor.VmContext) []string {
 		"-kernel", boot.Kernel, "-initrd", boot.Initrd,
 		"-append", "\"console=ttyS1 panic=1 no_timer_check\"",
 		"-realtime", "mlock=off", "-no-user-config", "-nodefaults", "-enable-kvm",
-		"-rtc", "base=utc,clock=vm,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
+		"-rtc", "base=utc,clock=host,driftfix=slew", "-no-reboot", "-display", "none", "-boot", "strict=on",
 		"-m", memParams, "-smp", cpuParams,
 		"-qmp", fmt.Sprintf("unix:%s,server,nowait", qc.qmpSockName),
 		"-chardev", fmt.Sprintf("socket,id=charconsole0,path=%s,server,nowait", ctx.ConsoleSockName),


### PR DESCRIPTION
Get wrong date in vm if template function is opened.
The root cause is hwclock cannot get right date from /dev/rtc that
is controled by rtc clock option.

Change this option to host will fix the issue.

Signed-off-by: Hui Zhu <teawater@hyper.sh>