### PR TITLE
VmContext.loop: Hold ctx.lock when access ctx.handler to fix crash

### DIFF
--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -11,7 +11,13 @@ import (
 )
 
 func (ctx *VmContext) loop() {
-	for ctx.handler != nil {
+	for {
+		ctx.lock.Lock()
+		handler := ctx.handler
+		ctx.lock.Unlock()
+		if handler == nil {
+			break
+		}
 		ev, ok := <-ctx.Hub
 		if !ok {
 			ctx.Log(ERROR, "hub chan has already been closed")
@@ -21,7 +27,7 @@ func (ctx *VmContext) loop() {
 			continue
 		}
 		ctx.Log(TRACE, "main event loop got message %d(%s)", ev.Event(), EventString(ev.Event()))
-		ctx.handler(ctx, ev)
+		handler(ctx, ev)
 	}
 
 	// Unless the ctx.Hub channel is drained, processes sending operations can


### PR DESCRIPTION
Got following crash in hyperd:
E0409 03:06:59.520358   30295 json.go:458] SB[vm-QctatzSfUb] tty socket closed, quit the the reading goroutine: read unix @->/var/run/hyper/vm-QctatzSfUb/tty.sock: use of closed
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x93c26a]
goroutine 33274 [running]:
github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*VmContext).loop(0xc42171eb00)
/root/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/hypervisor.go:24 +0x20a
created by github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*VmContext).Launch
/root/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/hypervisor.go:92

The root cause is VmContext.loop access ctx.handler without lock.
Add code hold ctx.lock to handle the issue.

Signed-off-by: Hui Zhu <teawater@hyper.sh>