### PR TITLE
QemuContext.qmpSend: new function that check ctx status before send d…

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -235,6 +235,18 @@ func (ctx *VmContext) IsRunning() bool {
 	return running
 }
 
+func (ctx *VmContext) IsClosedLocked() bool {
+	return ctx.current == StateNone
+}
+
+func (ctx *VmContext) Rlock() {
+	ctx.lock.RLock()
+}
+
+func (ctx *VmContext) RUnlock() {
+	ctx.lock.RUnlock()
+}
+
 // User API
 func (ctx *VmContext) SetNetworkEnvironment(net *api.SandboxConfig) {
 	ctx.lock.Lock()


### PR DESCRIPTION
…ata to qc.qmp

Got following panic in hyperd:
hyperd[26359]: E0326 06:39:44.147320   26359 stop.go:20] failed to shuting down: not in running state
hyperd[26359]: panic: send on closed channel
hyperd[26359]: goroutine 28404 [running]:
hyperd[26359]: github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/qemu.newDiskDelSession(0xc421f0e2c0, 0xc422aa6180, 0x1, 0x219a420, 0xc420b38880
hyperd[26359]: /root/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/qemu/qmp_wrapper.go:80 +0x4bd
hyperd[26359]: github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/qemu.(*QemuContext).RemoveDisk(0xc422aa6180, 0xc421f0e2c0, 0xc42035cb00, 0x219a
hyperd[26359]: /root/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/qemu/qemu.go:259 +0x61
hyperd[26359]: github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*DiskContext).remove.func1(0xc423c4ac90, 0xc420bc0240)
hyperd[26359]: /root/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/disk.go:127 +0xd0
hyperd[26359]: created by github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor.(*DiskContext).remove
hyperd[26359]: /root/gopath/src/github.com/hyperhq/hyperd/vendor/github.com/hyperhq/runv/hypervisor/disk.go:125 +0x18e

The reason is qc.qmp will be closed in QemuContext.Close when ctx closed.
But high level code doesn't know that and keep send data to qc.qmp.

Add this patch check the ctx status before send data to qc.qmp to handle
the issue.

Signed-off-by: Hui Zhu <teawater@hyper.sh>