### PR TITLE
BootConfig: add GDBTCPPort

### DIFF
--- a/hypervisor/context.go
+++ b/hypervisor/context.go
@@ -62,6 +62,8 @@ type VmContext struct {
 
 	logPrefix string
 
+	GDBTCPPort int
+
 	lock      sync.RWMutex //protect update of context
 	idLock    sync.Mutex
 	pauseLock sync.Mutex
@@ -140,6 +142,7 @@ func InitContext(id string, hub chan VmEvent, client chan *types.VmResponse, dc 
 		logPrefix:             fmt.Sprintf("SB[%s] ", id),
 		sockConnected:         make(chan bool),
 		cancelWatchHyperstart: make(chan struct{}),
+		GDBTCPPort:            boot.GDBTCPPort,
 	}
 	ctx.networks.sandbox = ctx
 

--- a/hypervisor/driver.go
+++ b/hypervisor/driver.go
@@ -22,6 +22,7 @@ type BootConfig struct {
 	Initrd           string
 	Bios             string
 	Cbfs             string
+	GDBTCPPort       int
 
 	// For network QoS (kilobytes/s)
 	InboundAverage  string

--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -86,7 +86,9 @@ func (ctx *VmContext) Launch() {
 		ctx.hyperstart, err = libhyperstart.NewHyperstart(ctx.Id, ctx.ctlSockAddr(), ctx.ttySockAddr(), 1, false, true)
 	} else {
 		ctx.hyperstart, err = libhyperstart.NewHyperstart(ctx.Id, ctx.ctlSockAddr(), ctx.ttySockAddr(), 1, true, false)
-		go ctx.watchHyperstart()
+		if ctx.GDBTCPPort == 0 {
+			go ctx.watchHyperstart()
+		}
 	}
 	if err != nil {
 		ctx.Log(ERROR, "failed to create hypervisor")

--- a/hypervisor/qemu/qemu_process.go
+++ b/hypervisor/qemu/qemu_process.go
@@ -128,6 +128,10 @@ func launchQemu(qc *QemuContext, ctx *hypervisor.VmContext) {
 
 	args := qc.arguments(ctx)
 	args = append(args, "-daemonize", "-pidfile", qc.qemuPidFile, "-D", qc.qemuLogFile.Name)
+	if ctx.GDBTCPPort != 0 {
+		args = append(args, "-gdb", fmt.Sprintf("tcp::%d", ctx.GDBTCPPort))
+		glog.Infof("qemu GDB TCP port is %d", ctx.GDBTCPPort)
+	}
 	if ctx.Boot.EnableVsock && qc.driver.hasVsock && ctx.GuestCid > 0 {
 		addr := ctx.NextPciAddr()
 		vsockDev := fmt.Sprintf("vhost-vsock-pci,id=vsock0,bus=pci.0,addr=%x,guest-cid=%d", addr, ctx.GuestCid)


### PR DESCRIPTION
If GDBTCPPort set to non-zero, launchQemu will add "-gdb tcp::xxx" to qemu
arguments.
Then GDB can connect this port to debug guest kernel.

Signed-off-by: Hui Zhu <teawater@hyper.sh>